### PR TITLE
Add Race model and factory hydration

### DIFF
--- a/schema/character.py
+++ b/schema/character.py
@@ -16,6 +16,7 @@ class Character(BaseModel):
     ability_scores: dict[str, AbilityScore]
     proficiency_bonus: int
     skills: dict[str, Skill]
+    race: UUID
     features: list[UUID]
     inventory: list[UUID]
     classes: list[CharacterClass]

--- a/schema/factory.py
+++ b/schema/factory.py
@@ -3,12 +3,13 @@ from schema.character import Character
 from schema.feature import Feature
 from schema.class_ import Class
 from schema.subclass import Subclass
+from schema.race import Race
 
 TYPE_MAP = {
     "character": Character,
     "class": Class,
     "subclass": Subclass,
-    "race": None,
+    "race": Race,
     "background": None,
     "feature": Feature,
     "item": None,

--- a/schema/race.py
+++ b/schema/race.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+from uuid import UUID
+
+from schema.primitives import Modifier
+
+
+class Race(BaseModel):
+    features: list[UUID]
+    modifiers: list[Modifier]

--- a/tests/test_character_level.py
+++ b/tests/test_character_level.py
@@ -24,6 +24,7 @@ def test_character_level_sum():
         ability_scores=ability_scores,
         proficiency_bonus=2,
         skills=skills,
+        race=uuid4(),
         features=[],
         inventory=[],
         classes=[first, second],

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,6 +8,7 @@ from schema.character import Character, CharacterClass
 from schema.class_ import Class
 from schema.subclass import Subclass
 from schema.factory import hydrate
+from schema.race import Race
 from store.game_obj import GameObject
 
 def test_primitives_and_feature():
@@ -26,11 +27,13 @@ def test_character_and_related_models_and_hydrate():
     ability_scores = {"str": {"proficient": True, "value": 10, "modifier": 0}}
     skills = {"acrobatics": {"proficient": "none", "modifier": 0}}
     class_entry = {"class_id": uuid4(), "level": 1}
+    race_id = uuid4()
     char = Character(
         ac=10,
         ability_scores=ability_scores,
         proficiency_bonus=2,
         skills=skills,
+        race=race_id,
         features=[],
         inventory=[],
         classes=[class_entry],
@@ -47,7 +50,14 @@ def test_character_and_related_models_and_hydrate():
     game_obj_char = GameObject(name="hero", type="character", data=char.dict())
     hydrated = hydrate(game_obj_char)
     assert isinstance(hydrated, Character)
+    assert hydrated.race == race_id
 
     unknown = GameObject(name="mystery", type="mystery", data={})
     with pytest.raises(ValueError):
         hydrate(unknown)
+
+    mod = Modifier(target="stats.speed", op="set", value=30)
+    race = Race(features=[uuid4()], modifiers=[mod])
+    game_obj_race = GameObject(name="elf", type="race", data=race.dict())
+    hydrated_race = hydrate(game_obj_race)
+    assert isinstance(hydrated_race, Race)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -96,3 +96,36 @@ def test_livecharacter_init_and_load_features(monkeypatch):
     assert dummy.grants == [grant_mod.value]
 
     cw.LiveCharacter.grant(dummy, uuid4())
+
+
+def test_load_features_includes_race(monkeypatch):
+    set_mod = Modifier(target="stats.hp", op="set", value=1)
+    race_mod = Modifier(target="stats.hp", op="add", value=2)
+    feat_obj = SimpleNamespace(modifiers=[set_mod])
+    race_obj = SimpleNamespace(features=["feat"], modifiers=[race_mod])
+
+    class DummyDAO:
+        def get_by_id(self, id):
+            return {"feat": feat_obj, "race": race_obj}[id]
+
+    class DummyLC:
+        def __init__(self):
+            self.features = []
+            self.set_calls = []
+            self.grants = []
+            self.dao = DummyDAO()
+            self.data = SimpleNamespace(features=[], race="race")
+
+        def set_data(self, t, v, op):
+            self.set_calls.append((t, v, op))
+
+        def grant(self, v):
+            self.grants.append(v)
+
+    monkeypatch.setattr(cw, "hydrate", lambda x: x)
+    dummy = DummyLC()
+    dummy._load_race = types.MethodType(cw.LiveCharacter._load_race, dummy)
+    cw.LiveCharacter.load_features(dummy)
+    assert dummy.features == [feat_obj]
+    assert ("stats.hp", 1, "set") in dummy.set_calls
+    assert ("stats.hp", 2, "add") in dummy.set_calls

--- a/wrappers/character_wrapper.py
+++ b/wrappers/character_wrapper.py
@@ -17,13 +17,31 @@ class LiveCharacter(LiveObject):
     def grant(self, id: UUID) -> None:
         pass
 
+    def _load_race(self) -> None:
+        data = getattr(self, "data", None)
+        race_id = getattr(data, "race", None)
+        if not race_id:
+            return
+        race_obj = hydrate(self.dao.get_by_id(race_id))
+        for feature_id in race_obj.features:
+            feature_obj = hydrate(self.dao.get_by_id(feature_id))
+            self.features.append(feature_obj)
+        for mod in race_obj.modifiers:
+            if mod.op in {"set", "add"}:
+                self.set_data(mod.target, mod.value, mod.op)
+            elif mod.op == "grant":
+                self.grant(mod.value)
+            else:
+                raise ValueError("Modifier operation is invalid")
+
     def load_features(self) -> None:
         if not getattr(self, "features", None):
-            feature_ids = getattr(getattr(self, "data", {}), "features", [])
+            data = getattr(self, "data", None)
             self.features = []
-            for feature_id in feature_ids:
+            for feature_id in getattr(data, "features", []):
                 feature_obj = hydrate(self.dao.get_by_id(feature_id))
                 self.features.append(feature_obj)
+            self._load_race()
         for feature_obj in self.features:
             for mod in feature_obj.modifiers:
                 if mod.op in {"set", "add"}:


### PR DESCRIPTION
## Summary
- Add Race schema with feature and modifier support
- Map `race` objects in the factory to the new Race schema
- Integrate race into Character and apply race features in live wrapper
- Extend schema and wrapper tests to cover race loading
- Refactor race feature loading into a dedicated helper for `LiveCharacter`