### PR TITLE
Add Background schema and factory mapping

### DIFF
--- a/schema/background.py
+++ b/schema/background.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+from schema.primitives import Modifier
+
+
+class Background(BaseModel):
+    description: str
+    modifiers: list[Modifier]

--- a/schema/character.py
+++ b/schema/character.py
@@ -16,6 +16,7 @@ class Character(BaseModel):
     ability_scores: dict[str, AbilityScore]
     proficiency_bonus: int
     skills: dict[str, Skill]
+    background: UUID
     features: list[UUID]
     inventory: list[UUID]
     classes: list[CharacterClass]

--- a/schema/factory.py
+++ b/schema/factory.py
@@ -3,13 +3,14 @@ from schema.character import Character
 from schema.feature import Feature
 from schema.class_ import Class
 from schema.subclass import Subclass
+from schema.background import Background
 
 TYPE_MAP = {
     "character": Character,
     "class": Class,
     "subclass": Subclass,
     "race": None,
-    "background": None,
+    "background": Background,
     "feature": Feature,
     "item": None,
     "spell": None,

--- a/tests/test_character_level.py
+++ b/tests/test_character_level.py
@@ -24,6 +24,7 @@ def test_character_level_sum():
         ability_scores=ability_scores,
         proficiency_bonus=2,
         skills=skills,
+        background=uuid4(),
         features=[],
         inventory=[],
         classes=[first, second],

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 
 from schema.primitives import AbilityScore, Skill, Modifier
 from schema.feature import Feature
+from schema.background import Background
 from schema.character import Character, CharacterClass
 from schema.class_ import Class
 from schema.subclass import Subclass
@@ -18,6 +19,9 @@ def test_primitives_and_feature():
     feat = Feature(description="x", modifiers=[modifier])
     assert feat.description == "x"
 
+    bg = Background(description="y", modifiers=[modifier])
+    assert bg.modifiers[0].op == "add"
+
     with pytest.raises(ValidationError):
         Skill(proficient="invalid", modifier=0)
 
@@ -26,11 +30,13 @@ def test_character_and_related_models_and_hydrate():
     ability_scores = {"str": {"proficient": True, "value": 10, "modifier": 0}}
     skills = {"acrobatics": {"proficient": "none", "modifier": 0}}
     class_entry = {"class_id": uuid4(), "level": 1}
+    background_id = uuid4()
     char = Character(
         ac=10,
         ability_scores=ability_scores,
         proficiency_bonus=2,
         skills=skills,
+        background=background_id,
         features=[],
         inventory=[],
         classes=[class_entry],
@@ -47,6 +53,10 @@ def test_character_and_related_models_and_hydrate():
     game_obj_char = GameObject(name="hero", type="character", data=char.dict())
     hydrated = hydrate(game_obj_char)
     assert isinstance(hydrated, Character)
+    assert hydrated.background == background_id
+
+    bg_obj = GameObject(name="acolyte", type="background", data={"description": "y", "modifiers": []})
+    assert isinstance(hydrate(bg_obj), Background)
 
     unknown = GameObject(name="mystery", type="mystery", data={})
     with pytest.raises(ValueError):

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -6,6 +6,7 @@ import pytest
 from wrappers import live_object
 from wrappers import character_wrapper as cw
 from schema.primitives import Modifier
+from store.game_obj import GameObject
 
 
 class DummyGameObject:
@@ -96,3 +97,44 @@ def test_livecharacter_init_and_load_features(monkeypatch):
     assert dummy.grants == [grant_mod.value]
 
     cw.LiveCharacter.grant(dummy, uuid4())
+
+
+def test_livecharacter_apply_background():
+    set_mod = Modifier(target="stats.hp", op="set", value=1)
+    add_mod = Modifier(target="stats.hp", op="add", value=2)
+    grant_mod = Modifier(target="", op="grant", value=uuid4())
+    bad_mod = SimpleNamespace(target="", op="oops", value=0)
+
+    good_bg = GameObject(
+        name="acolyte",
+        type="background",
+        data={"description": "d", "modifiers": [set_mod, add_mod, grant_mod]},
+    )
+    bad_bg = GameObject(
+        name="acolyte",
+        type="background",
+        data={"description": "d", "modifiers": [bad_mod]},
+    )
+
+    class DummyLC:
+        def __init__(self, bg_obj):
+            self.dao = SimpleNamespace(get_by_id=lambda _id: bg_obj)
+            self.data = SimpleNamespace(background=uuid4())
+            self.set_calls = []
+            self.grants = []
+
+        def set_data(self, t, v, op):
+            self.set_calls.append((t, v, op))
+
+        def grant(self, value):
+            self.grants.append(value)
+
+    dummy = DummyLC(good_bg)
+    cw.LiveCharacter.apply_background(dummy)
+    assert dummy.set_calls[0] == ("stats.hp", 1, "set")
+    assert dummy.set_calls[1] == ("stats.hp", 2, "add")
+    assert dummy.grants == [grant_mod.value]
+
+    dummy_bad = DummyLC(bad_bg)
+    with pytest.raises(ValueError):
+        cw.LiveCharacter.apply_background(dummy_bad)

--- a/wrappers/character_wrapper.py
+++ b/wrappers/character_wrapper.py
@@ -12,10 +12,24 @@ class LiveCharacter(LiveObject):
         # always invoked.
         builtins.super(LiveCharacter, self).__init__(game_obj)
         self.features: list = []
+        self.apply_background()
         self.load_features()
     
     def grant(self, id: UUID) -> None:
         pass
+
+    def apply_background(self) -> None:
+        background_id = getattr(getattr(self, "data", None), "background", None)
+        if not background_id:
+            return
+        background_obj = hydrate(self.dao.get_by_id(background_id))
+        for mod in background_obj.modifiers:
+            if mod.op in {"set", "add"}:
+                self.set_data(mod.target, mod.value, mod.op)
+            elif mod.op == "grant":
+                self.grant(mod.value)
+            else:
+                raise ValueError("Modifier operation is invalid")
 
     def load_features(self) -> None:
         if not getattr(self, "features", None):


### PR DESCRIPTION
## Summary
- model a Background with description and modifiers
- add Background type to the factory mapping
- link characters to backgrounds via UUID
- apply background modifiers when constructing `LiveCharacter`
- cover Background hydration and wrapper behavior in tests