### PR TITLE
Add spell and spellcasting models

### DIFF
--- a/schema/character.py
+++ b/schema/character.py
@@ -1,8 +1,9 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from uuid import UUID
-from typing import Optional, Any
+from typing import Optional
 
 from schema.primitives import AbilityScore, Skill
+from schema.spellcasting import Spellcasting
 
 
 class CharacterClass(BaseModel):
@@ -19,7 +20,7 @@ class Character(BaseModel):
     features: list[UUID]
     inventory: list[UUID]
     classes: list[CharacterClass]
-    spellcasting: Optional[dict[Any, Any]]  # change when we work on spellcasting object
+    spellcasting: dict[str, Spellcasting] = Field(default_factory=dict)
 
     @property
     def level(self) -> int:

--- a/schema/class_.py
+++ b/schema/class_.py
@@ -1,9 +1,11 @@
 from pydantic import BaseModel
 from uuid import UUID
+from typing import Optional
 
 
 class Class(BaseModel):
     hit_die: int
     features: dict[int, list[UUID]]
     subclasses: list[UUID]
+    spellcasting: Optional[UUID] = None
 

--- a/schema/factory.py
+++ b/schema/factory.py
@@ -3,6 +3,8 @@ from schema.character import Character
 from schema.feature import Feature
 from schema.class_ import Class
 from schema.subclass import Subclass
+from schema.spell import Spell
+from schema.spellcasting import Spellcasting
 
 TYPE_MAP = {
     "character": Character,
@@ -12,7 +14,8 @@ TYPE_MAP = {
     "background": None,
     "feature": Feature,
     "item": None,
-    "spell": None,
+    "spell": Spell,
+    "spellcasting": Spellcasting,
     "monster": None,
     "npc": None,
 }

--- a/schema/spell.py
+++ b/schema/spell.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class Spell(BaseModel):
+    level: int
+    school: str
+    casting_time: str
+    range: str
+    components: list[str]
+    duration: str
+    description: str
+    higher_levels: Optional[str] = None
+    ritual: bool = False
+    concentration: bool = False
+    materials: Optional[str] = None

--- a/schema/spellcasting.py
+++ b/schema/spellcasting.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+from typing import Dict, Optional
+from uuid import UUID
+
+class Spellcasting(BaseModel):
+    ability: str
+    spell_list: list[UUID]
+    slots: Dict[int, Dict[int, int]]
+    spells_known: Optional[Dict[int, int]] = None
+    cantrips_known: Optional[Dict[int, int]] = None

--- a/tests/test_character_level.py
+++ b/tests/test_character_level.py
@@ -27,7 +27,6 @@ def test_character_level_sum():
         features=[],
         inventory=[],
         classes=[first, second],
-        spellcasting=None,
     )
 
     assert character.level == 5

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -7,6 +7,8 @@ from schema.feature import Feature
 from schema.character import Character, CharacterClass
 from schema.class_ import Class
 from schema.subclass import Subclass
+from schema.spell import Spell
+from schema.spellcasting import Spellcasting
 from schema.factory import hydrate
 from store.game_obj import GameObject
 
@@ -34,7 +36,6 @@ def test_character_and_related_models_and_hydrate():
         features=[],
         inventory=[],
         classes=[class_entry],
-        spellcasting=None,
     )
     assert char.classes[0].level == 1
 
@@ -51,3 +52,33 @@ def test_character_and_related_models_and_hydrate():
     unknown = GameObject(name="mystery", type="mystery", data={})
     with pytest.raises(ValueError):
         hydrate(unknown)
+
+
+def test_spell_and_spellcasting_and_mount():
+    spell = Spell(
+        level=1,
+        school="evocation",
+        casting_time="1 action",
+        range="60 feet",
+        components=["V", "S"],
+        duration="Instantaneous",
+        description="A bolt of fire",
+    )
+    assert spell.level == 1
+
+    spell_list = [uuid4(), uuid4()]
+    slots = {1: {1: 2}, 2: {1: 3, 2: 1}}
+    sc = Spellcasting(ability="int", spell_list=spell_list, slots=slots)
+    assert sc.slots[2][2] == 1
+
+    sc_obj = GameObject(name="Wizard Spellcasting", type="spellcasting", data=sc.dict())
+    spell_obj = GameObject(name="Fire Bolt", type="spell", data=spell.dict())
+
+    hydrated_sc = hydrate(sc_obj)
+    hydrated_spell = hydrate(spell_obj)
+
+    assert isinstance(hydrated_sc, Spellcasting)
+    assert isinstance(hydrated_spell, Spell)
+
+    cls = Class(hit_die=6, features={1: [uuid4()]}, subclasses=[], spellcasting=sc_obj.id)
+    assert cls.spellcasting == sc_obj.id

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -6,6 +6,12 @@ import pytest
 from wrappers import live_object
 from wrappers import character_wrapper as cw
 from schema.primitives import Modifier
+from schema.spell import Spell
+from schema.spellcasting import Spellcasting
+from schema.class_ import Class
+from schema.character import Character, CharacterClass
+from store.game_obj import GameObject
+from schema.factory import hydrate
 
 
 class DummyGameObject:
@@ -18,10 +24,13 @@ class DummyGameObject:
 
 
 class DummyDAO:
-    def __init__(self):
+    def __init__(self, objects=None):
         self.updated = None
+        self.objects = objects or {}
     def update(self, obj):
         self.updated = obj
+    def get_by_id(self, obj_id):
+        return self.objects[obj_id]
 
 
 def create_live_object():
@@ -96,3 +105,56 @@ def test_livecharacter_init_and_load_features(monkeypatch):
     assert dummy.grants == [grant_mod.value]
 
     cw.LiveCharacter.grant(dummy, uuid4())
+
+
+def test_load_spellcasting():
+    spell = Spell(
+        level=1,
+        school="evocation",
+        casting_time="1 action",
+        range="60 feet",
+        components=["V", "S"],
+        duration="Instantaneous",
+        description="A bolt of fire",
+    )
+    spell_obj = GameObject(name="Fire Bolt", type="spell", data=spell.dict())
+
+    sc = Spellcasting(ability="int", spell_list=[spell_obj.id], slots={1: {1: 2}})
+    sc_obj = GameObject(name="Wizard Spellcasting", type="spellcasting", data=sc.dict())
+
+    cls_model = Class(hit_die=6, features={}, subclasses=[], spellcasting=sc_obj.id)
+    cls_obj = GameObject(name="Wizard", type="class", data=cls_model.dict())
+
+    char_class = CharacterClass(class_id=cls_obj.id, level=1)
+    character = Character(
+        ac=10,
+        ability_scores={},
+        proficiency_bonus=2,
+        skills={},
+        features=[],
+        inventory=[],
+        classes=[char_class],
+    )
+    char_obj = GameObject(name="Hero", type="character", data=character.dict())
+
+    objects = {
+        cls_obj.id: cls_obj,
+        sc_obj.id: sc_obj,
+        spell_obj.id: spell_obj,
+    }
+    dummy = SimpleNamespace(
+        dao=DummyDAO(objects),
+        raw=char_obj,
+        data=hydrate(char_obj),
+        spells={},
+    )
+
+    def process_change(self):
+        self.data = hydrate(self.raw)
+        self.dao.update(self.raw)
+
+    dummy.process_change = types.MethodType(process_change, dummy)
+
+    cw.LiveCharacter.load_spellcasting(dummy)
+    assert "Wizard" in dummy.data.spellcasting
+    assert dummy.spells["Wizard"][0].description == "A bolt of fire"

--- a/wrappers/character_wrapper.py
+++ b/wrappers/character_wrapper.py
@@ -12,7 +12,9 @@ class LiveCharacter(LiveObject):
         # always invoked.
         builtins.super(LiveCharacter, self).__init__(game_obj)
         self.features: list = []
+        self.spells: dict = {}
         self.load_features()
+        self.load_spellcasting()
     
     def grant(self, id: UUID) -> None:
         pass
@@ -32,6 +34,26 @@ class LiveCharacter(LiveObject):
                     self.grant(mod.value)
                 else:
                     raise ValueError("Modifier operation is invalid")
+
+    def load_spellcasting(self) -> None:
+        spellcasting_map = {}
+        spells_map = {}
+        for class_entry in getattr(getattr(self, "data", {}), "classes", []):
+            class_obj = self.dao.get_by_id(class_entry.class_id)
+            hydrated_class = hydrate(class_obj)
+            spellcasting_id = getattr(hydrated_class, "spellcasting", None)
+            if spellcasting_id:
+                sc_obj = self.dao.get_by_id(spellcasting_id)
+                hydrated_sc = hydrate(sc_obj)
+                spellcasting_map[class_obj.name] = hydrated_sc.dict()
+                spells_map[class_obj.name] = [
+                    hydrate(self.dao.get_by_id(spell_id))
+                    for spell_id in hydrated_sc.spell_list
+                ]
+        if spellcasting_map:
+            self.raw.data.setdefault("spellcasting", {}).update(spellcasting_map)
+            self.process_change()
+        self.spells = spells_map
                 
 
     


### PR DESCRIPTION
## Summary
- add Spell model mirroring 5e SRD spell data
- create Spellcasting model with slots, lists, and ability stat
- allow classes and characters to reference spellcasting; hydrate spell and spellcasting objects
- load class spellcasting and spells on LiveCharacter wrapper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68955a705dc08323a07fe88c191c8b7c