### PR TITLE
Refactor for Pydantic v2 methods

### DIFF
--- a/schema/factory.py
+++ b/schema/factory.py
@@ -26,5 +26,5 @@ def hydrate(game_object: GameObject):
     cls = TYPE_MAP.get(game_object.type)
     if not cls:
         raise ValueError(f"Unknown type: {game_object.type}")
-    return cls.parse_obj(game_object.data)
+    return cls.model_validate(game_object.data)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -54,7 +54,7 @@ def test_character_and_related_models_and_hydrate():
     subcls = Subclass(parent=uuid4(), features={1: [uuid4()]})
     assert subcls.features
 
-    game_obj_char = GameObject(name="hero", type="character", data=char.dict())
+    game_obj_char = GameObject(name="hero", type="character", data=char.model_dump())
     hydrated = hydrate(game_obj_char)
     assert isinstance(hydrated, Character)
     assert hydrated.background == background_id
@@ -84,8 +84,8 @@ def test_spell_and_spellcasting_and_mount():
     sc = Spellcasting(ability="int", spell_list=spell_list, slots=slots)
     assert sc.slots[2][2] == 1
 
-    sc_obj = GameObject(name="Wizard Spellcasting", type="spellcasting", data=sc.dict())
-    spell_obj = GameObject(name="Fire Bolt", type="spell", data=spell.dict())
+    sc_obj = GameObject(name="Wizard Spellcasting", type="spellcasting", data=sc.model_dump())
+    spell_obj = GameObject(name="Fire Bolt", type="spell", data=spell.model_dump())
 
     hydrated_sc = hydrate(sc_obj)
     hydrated_spell = hydrate(spell_obj)
@@ -97,6 +97,6 @@ def test_spell_and_spellcasting_and_mount():
     assert cls.spellcasting == sc_obj.id
     mod = Modifier(target="stats.speed", op="set", value=30)
     race = Race(features=[uuid4()], modifiers=[mod])
-    game_obj_race = GameObject(name="elf", type="race", data=race.dict())
+    game_obj_race = GameObject(name="elf", type="race", data=race.model_dump())
     hydrated_race = hydrate(game_obj_race)
     assert isinstance(hydrated_race, Race)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -128,13 +128,13 @@ def test_load_spellcasting():
         duration="Instantaneous",
         description="A bolt of fire",
     )
-    spell_obj = GameObject(name="Fire Bolt", type="spell", data=spell.dict())
+    spell_obj = GameObject(name="Fire Bolt", type="spell", data=spell.model_dump())
 
     sc = Spellcasting(ability="int", spell_list=[spell_obj.id], slots={1: {1: 2}})
-    sc_obj = GameObject(name="Wizard Spellcasting", type="spellcasting", data=sc.dict())
+    sc_obj = GameObject(name="Wizard Spellcasting", type="spellcasting", data=sc.model_dump())
 
     cls_model = Class(hit_die=6, features={}, subclasses=[], spellcasting=sc_obj.id)
-    cls_obj = GameObject(name="Wizard", type="class", data=cls_model.dict())
+    cls_obj = GameObject(name="Wizard", type="class", data=cls_model.model_dump())
 
     char_class = CharacterClass(class_id=cls_obj.id, level=1)
     character = Character(
@@ -148,7 +148,7 @@ def test_load_spellcasting():
         inventory=[],
         classes=[char_class],
     )
-    char_obj = GameObject(name="Hero", type="character", data=character.dict())
+    char_obj = GameObject(name="Hero", type="character", data=character.model_dump())
 
     objects = {
         cls_obj.id: cls_obj,

--- a/wrappers/character_wrapper.py
+++ b/wrappers/character_wrapper.py
@@ -77,7 +77,7 @@ class LiveCharacter(LiveObject):
             if spellcasting_id:
                 sc_obj = self.dao.get_by_id(spellcasting_id)
                 hydrated_sc = hydrate(sc_obj)
-                spellcasting_map[class_obj.name] = hydrated_sc.dict()
+                spellcasting_map[class_obj.name] = hydrated_sc.model_dump()
                 spells_map[class_obj.name] = [
                     hydrate(self.dao.get_by_id(spell_id))
                     for spell_id in hydrated_sc.spell_list


### PR DESCRIPTION
## Summary
- replace deprecated `parse_obj` with `model_validate`
- swap deprecated `.dict()` calls for `.model_dump()`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895676a342c8323af38ff4bc0011e43