### PR TITLE
feat: integrate equipped items into live characters

### DIFF
--- a/schema/factory.py
+++ b/schema/factory.py
@@ -7,6 +7,7 @@ from schema.spell import Spell
 from schema.spellcasting import Spellcasting
 from schema.background import Background
 from schema.race import Race
+from schema.item import Item
 
 TYPE_MAP = {
     "character": Character,
@@ -15,7 +16,7 @@ TYPE_MAP = {
     "background": Background,
     "race": Race,
     "feature": Feature,
-    "item": None,
+    "item": Item,
     "spell": Spell,
     "spellcasting": Spellcasting,
     "monster": None,

--- a/schema/item.py
+++ b/schema/item.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from typing import Literal
+
+from schema.primitives import Modifier
+
+
+class Item(BaseModel):
+    category: Literal["weapon", "consumable", "armor"]
+    equipped: bool = False
+    modifiers: list[Modifier]
+    attack_modifier: int | None = None
+    damage_dice: str | None = None
+    damage_modifier: int | None = None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -12,6 +12,7 @@ from schema.spell import Spell
 from schema.spellcasting import Spellcasting
 from schema.factory import hydrate
 from schema.race import Race
+from schema.item import Item
 from store.game_obj import GameObject
 
 def test_primitives_and_feature():
@@ -100,3 +101,25 @@ def test_spell_and_spellcasting_and_mount():
     game_obj_race = GameObject(name="elf", type="race", data=race.model_dump())
     hydrated_race = hydrate(game_obj_race)
     assert isinstance(hydrated_race, Race)
+
+
+def test_item_and_hydrate():
+    mod = Modifier(target="stats.hp", op="add", value=5)
+    item = Item(
+        category="weapon",
+        equipped=True,
+        modifiers=[mod],
+        attack_modifier=1,
+        damage_dice="1d6",
+        damage_modifier=2,
+    )
+    assert item.equipped
+    assert item.attack_modifier == 1
+    assert item.damage_dice == "1d6"
+    assert item.damage_modifier == 2
+    game_obj_item = GameObject(name="Sword", type="item", data=item.model_dump())
+    hydrated_item = hydrate(game_obj_item)
+    assert isinstance(hydrated_item, Item)
+    assert hydrated_item.attack_modifier == 1
+    assert hydrated_item.damage_dice == "1d6"
+    assert hydrated_item.damage_modifier == 2

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -268,6 +268,47 @@ def test_load_race_invalid_modifier(monkeypatch):
     with pytest.raises(ValueError):
         cw.LiveCharacter._load_race(DummyLC())
 
+
+def test_load_items(monkeypatch):
+    add_mod = SimpleNamespace(target="stats.hp", op="add", value=2)
+    grant_mod = SimpleNamespace(target="", op="grant", value=uuid4())
+    bad_mod = SimpleNamespace(target="", op="oops", value=0)
+    item_eq = SimpleNamespace(equipped=True, modifiers=[add_mod, grant_mod])
+    item_uneq = SimpleNamespace(equipped=False, modifiers=[add_mod])
+    item_bad = SimpleNamespace(equipped=True, modifiers=[bad_mod])
+
+    class DummyDAO:
+        def __init__(self, objects):
+            self.objects = objects
+        def get_by_id(self, obj_id):
+            return self.objects[obj_id]
+
+    class DummyLC:
+        def __init__(self, dao, inventory):
+            self.items = []
+            self.dao = dao
+            self.data = SimpleNamespace(inventory=inventory)
+            self.set_calls = []
+            self.grants = []
+
+        def set_data(self, t, v, op):
+            self.set_calls.append((t, v, op))
+
+        def grant(self, value):
+            self.grants.append(value)
+
+    monkeypatch.setattr(cw, "hydrate", lambda x: x)
+
+    dummy = DummyLC(DummyDAO({"eq": item_eq, "uneq": item_uneq}), ["eq", "uneq"])
+    cw.LiveCharacter.load_items(dummy)
+    assert dummy.items == [item_eq, item_uneq]
+    assert dummy.set_calls == [("stats.hp", 2, "add")]
+    assert dummy.grants == [grant_mod.value]
+
+    dummy_bad = DummyLC(DummyDAO({"bad": item_bad}), ["bad"])
+    with pytest.raises(ValueError):
+        cw.LiveCharacter.load_items(dummy_bad)
+
     
 def test_livecharacter_init_feature_ids(monkeypatch):
     feature_id = uuid4()

--- a/wrappers/character_wrapper.py
+++ b/wrappers/character_wrapper.py
@@ -13,9 +13,11 @@ class LiveCharacter(LiveObject):
         builtins.super(LiveCharacter, self).__init__(game_obj)
         self.features: list = []
         self.spells: dict = {}
+        self.items: list = []
         self.apply_background()
         self.load_features()
         self.load_spellcasting()
+        self.load_items()
     
     def grant(self, id: UUID) -> None:
         pass
@@ -86,6 +88,21 @@ class LiveCharacter(LiveObject):
             self.raw.data.setdefault("spellcasting", {}).update(spellcasting_map)
             self.process_change()
         self.spells = spells_map
+
+    def load_items(self) -> None:
+        data = getattr(self, "data", None)
+        self.items = []
+        for item_id in getattr(data, "inventory", []):
+            item_obj = hydrate(self.dao.get_by_id(item_id))
+            self.items.append(item_obj)
+            if getattr(item_obj, "equipped", False):
+                for mod in item_obj.modifiers:
+                    if mod.op in {"set", "add"}:
+                        self.set_data(mod.target, mod.value, mod.op)
+                    elif mod.op == "grant":
+                        self.grant(mod.value)
+                    else:
+                        raise ValueError("Modifier operation is invalid")
                 
 
     


### PR DESCRIPTION
## Summary
- remove redundant feature list from `Item` and add `equipped` flag
- apply equipped item modifiers in `LiveCharacter.load_items`
- expand tests for item hydration and modifier application
- extend `Item` schema with optional attack and damage fields for weapons and consumables

## Testing
- `pip install 'pydantic>=2,<3' -U`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ef86df708323bfda37e79a16ffca