### PR TITLE
Enable rollables to reference character attributes

### DIFF
--- a/schema/background.py
+++ b/schema/background.py
@@ -7,3 +7,9 @@ class Background(BaseModel):
     description: str
     modifiers: list[Modifier]
     rollables: dict[str, Rollable] = Field(default_factory=dict)
+
+    def __init__(self, **data):
+        rollables = data.get("rollables", {})
+        if rollables:
+            data["rollables"] = {k: Rollable.model_validate(v) for k, v in rollables.items()}
+        super().__init__(**data)

--- a/schema/class_.py
+++ b/schema/class_.py
@@ -12,3 +12,9 @@ class Class(BaseModel):
     spellcasting: Optional[UUID] = None
     rollables: dict[str, Rollable] = Field(default_factory=dict)
 
+    def __init__(self, **data):
+        rollables = data.get("rollables", {})
+        if rollables:
+            data["rollables"] = {k: Rollable.model_validate(v) for k, v in rollables.items()}
+        super().__init__(**data)
+

--- a/schema/feature.py
+++ b/schema/feature.py
@@ -6,3 +6,9 @@ class Feature(BaseModel):
     description: str
     modifiers: list[Modifier]
     rollables: dict[str, Rollable] = Field(default_factory=dict)
+
+    def __init__(self, **data):
+        rollables = data.get("rollables", {})
+        if rollables:
+            data["rollables"] = {k: Rollable.model_validate(v) for k, v in rollables.items()}
+        super().__init__(**data)

--- a/schema/item.py
+++ b/schema/item.py
@@ -13,3 +13,9 @@ class Item(BaseModel):
     damage_dice: str | None = None
     damage_modifier: int | None = None
     rollables: dict[str, Rollable] = Field(default_factory=dict)
+
+    def __init__(self, **data):
+        rollables = data.get("rollables", {})
+        if rollables:
+            data["rollables"] = {k: Rollable.model_validate(v) for k, v in rollables.items()}
+        super().__init__(**data)

--- a/schema/race.py
+++ b/schema/race.py
@@ -9,3 +9,9 @@ class Race(BaseModel):
     features: list[UUID]
     modifiers: list[Modifier]
     rollables: dict[str, Rollable] = Field(default_factory=dict)
+
+    def __init__(self, **data):
+        rollables = data.get("rollables", {})
+        if rollables:
+            data["rollables"] = {k: Rollable.model_validate(v) for k, v in rollables.items()}
+        super().__init__(**data)

--- a/schema/rollable.py
+++ b/schema/rollable.py
@@ -1,29 +1,82 @@
 import random
 import re
-from pydantic import RootModel, field_validator
+from typing import ClassVar
+from pydantic import BaseModel, model_validator
 
 
-class Rollable(RootModel[str]):
-    @field_validator('root', mode='before')
+class Rollable(BaseModel):
+    dice: str
+    modifier: int | str = 0
+
+    _notation_re: ClassVar[re.Pattern] = re.compile(r"^(?:(\d*)d(\d+))(?:([+-]\d+))?\Z", re.IGNORECASE)
+    _dice_re: ClassVar[re.Pattern] = re.compile(r"^(?:(\d*)d(\d+))\Z", re.IGNORECASE)
+
+    def __init__(self, *args, **data):
+        if args:
+            if len(args) != 1 or data:
+                raise TypeError("Rollable accepts a single positional argument or keyword arguments")
+            data = self._coerce(args[0])
+        else:
+            data = self._coerce(data) if isinstance(data, (int, str)) else data
+        super().__init__(**data)
+
     @classmethod
-    def _coerce_notation(cls, v):
+    def model_validate(cls, v, **kwargs):
+        data = cls._coerce(v)
+        return super().model_validate(data, **kwargs)
+
+    @classmethod
+    @model_validator(mode="before")
+    def _validate_before(cls, v):
+        return cls._coerce(v)
+
+    @classmethod
+    def _coerce(cls, v):
+        if isinstance(v, cls):
+            return v.model_dump()
+        if isinstance(v, dict):
+            return v
         if isinstance(v, int):
-            return str(v)
+            return {"dice": "1d20", "modifier": v}
         if isinstance(v, str):
-            return v.strip()
-        raise TypeError('Rollable must be int or dice notation string')
+            n = v.strip()
+            if n.isdigit() or (n.startswith("-") and n[1:].isdigit()):
+                return {"dice": "1d20", "modifier": int(n)}
+            m = cls._notation_re.fullmatch(n)
+            if not m:
+                raise ValueError(f"Invalid dice notation: {n}")
+            count = m.group(1)
+            sides = m.group(2)
+            mod = int(m.group(3)) if m.group(3) else 0
+            dice = f"{count}d{sides}" if count else f"d{sides}"
+            return {"dice": dice, "modifier": mod}
+        raise TypeError("Rollable must be int, str, or dict")
 
-    _dice_re = re.compile(r"^(?:(\d*)d(\d+))(?:([+-]\d+))?\Z", re.IGNORECASE)
-
-    def roll(self) -> int:
-        n = self.root
-        if n.isdigit() or (n.startswith('-') and n[1:].isdigit()):
-            return random.randint(1, 20) + int(n)
-        m = self._dice_re.fullmatch(n)
+    def roll(self, character=None) -> int:
+        m = self._dice_re.fullmatch(self.dice)
         if not m:
-            raise ValueError(f'Invalid dice notation: {n}')
+            raise ValueError(f"Invalid dice notation: {self.dice}")
         count = int(m.group(1)) if m.group(1) else 1
         sides = int(m.group(2))
-        mod = int(m.group(3)) if m.group(3) else 0
-        total = sum(random.randint(1, sides) for _ in range(count)) + mod
+        total = sum(random.randint(1, sides) for _ in range(count))
+        total += self._resolve_modifier(character)
         return total
+
+    def _resolve_modifier(self, character) -> int:
+        if isinstance(self.modifier, int):
+            return self.modifier
+        if isinstance(self.modifier, str):
+            if character is None:
+                raise ValueError("Character is required to resolve modifier")
+            abilities = getattr(character, "ability_scores", {})
+            if self.modifier in abilities:
+                return abilities[self.modifier].modifier
+            skills = getattr(character, "skills", {})
+            if self.modifier in skills:
+                return skills[self.modifier].modifier
+            attr = getattr(character, self.modifier, None)
+            if isinstance(attr, int):
+                return attr
+            raise ValueError(f"Unknown modifier reference: {self.modifier}")
+        raise TypeError("Modifier must be int or str")
+

--- a/schema/spell.py
+++ b/schema/spell.py
@@ -15,3 +15,9 @@ class Spell(BaseModel):
     concentration: bool = False
     materials: Optional[str] = None
     rollables: dict[str, Rollable] = Field(default_factory=dict)
+
+    def __init__(self, **data):
+        rollables = data.get("rollables", {})
+        if rollables:
+            data["rollables"] = {k: Rollable.model_validate(v) for k, v in rollables.items()}
+        super().__init__(**data)

--- a/schema/spellcasting.py
+++ b/schema/spellcasting.py
@@ -10,3 +10,9 @@ class Spellcasting(BaseModel):
     spells_known: Optional[Dict[int, int]] = None
     cantrips_known: Optional[Dict[int, int]] = None
     rollables: dict[str, Rollable] = Field(default_factory=dict)
+
+    def __init__(self, **data):
+        rollables = data.get("rollables", {})
+        if rollables:
+            data["rollables"] = {k: Rollable.model_validate(v) for k, v in rollables.items()}
+        super().__init__(**data)

--- a/schema/subclass.py
+++ b/schema/subclass.py
@@ -9,3 +9,9 @@ class Subclass(BaseModel):
     features: dict[int, list[UUID]]
     rollables: dict[str, Rollable] = Field(default_factory=dict)
 
+    def __init__(self, **data):
+        rollables = data.get("rollables", {})
+        if rollables:
+            data["rollables"] = {k: Rollable.model_validate(v) for k, v in rollables.items()}
+        super().__init__(**data)
+

--- a/tests/test_rollable.py
+++ b/tests/test_rollable.py
@@ -1,7 +1,9 @@
 import random
 import pytest
+from uuid import uuid4
 
 from schema.rollable import Rollable
+from schema.character import Character, CharacterClass
 
 
 def test_roll_int(monkeypatch):
@@ -28,11 +30,28 @@ def test_roll_single_die(monkeypatch):
 
 
 def test_invalid_notation():
-    r = Rollable('2f6')
     with pytest.raises(ValueError):
-        r.roll()
+        Rollable('2f6')
 
 
 def test_invalid_input_type():
     with pytest.raises(TypeError):
         Rollable(3.5)
+
+
+def test_roll_with_character_modifier(monkeypatch):
+    ability_scores = {"str": {"proficient": True, "value": 10, "modifier": 2}}
+    char = Character(
+        ac=10,
+        ability_scores=ability_scores,
+        proficiency_bonus=2,
+        skills={},
+        background=uuid4(),
+        race=uuid4(),
+        features=[],
+        inventory=[],
+        classes=[CharacterClass(class_id=uuid4(), level=1)],
+    )
+    r = Rollable({"dice": "1d20", "modifier": "str"})
+    monkeypatch.setattr(random, 'randint', lambda a, b: 10)
+    assert r.roll(char) == 12


### PR DESCRIPTION
## Summary
- expand `Rollable` to accept dice and character-based modifiers
- normalize rollables across schema models
- test character attribute modifiers in rollable rolls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68960e14b17c8323bc1b69170e65de69