### PR TITLE
Aggregate rollables onto live characters

### DIFF
--- a/schema/character.py
+++ b/schema/character.py
@@ -24,28 +24,31 @@ class Character(BaseModel):
     inventory: list[UUID]
     classes: list[CharacterClass]
     spellcasting: dict[str, Spellcasting] = Field(default_factory=dict)
-    rollables: dict[str, Rollable] = Field(default_factory=dict)
+    rollables: dict[str, dict[str, Rollable]] = Field(default_factory=dict)
 
     def __init__(self, **data):
         rollables = data.get("rollables", {})
         if rollables:
-            data["rollables"] = {k: Rollable.model_validate(v) for k, v in rollables.items()}
+            data["rollables"] = {
+                action: {name: Rollable.model_validate(r) for name, r in rmap.items()}
+                for action, rmap in rollables.items()
+            }
         super().__init__(**data)
 
     @property
-    def actions(self) -> Rollable | None:
+    def actions(self) -> dict[str, Rollable] | None:
         return self.rollables.get("action")
 
     @property
-    def bonus_actions(self) -> Rollable | None:
+    def bonus_actions(self) -> dict[str, Rollable] | None:
         return self.rollables.get("bonus_action")
 
     @property
-    def reactions(self) -> Rollable | None:
+    def reactions(self) -> dict[str, Rollable] | None:
         return self.rollables.get("reaction")
 
     @property
-    def free(self) -> Rollable | None:
+    def free(self) -> dict[str, Rollable] | None:
         return self.rollables.get("free")
 
     @property

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -48,10 +48,10 @@ def test_character_and_related_models_and_hydrate():
         features=[],
         inventory=[],
         classes=[class_entry],
-        rollables={"action": "1d20", "bonus_action": 5},
+        rollables={"action": {"base": "1d20"}, "bonus_action": {"base": 5}},
     )
-    assert isinstance(char.actions, Rollable)
-    assert isinstance(char.bonus_actions, Rollable)
+    assert isinstance(char.actions["base"], Rollable)
+    assert isinstance(char.bonus_actions["base"], Rollable)
     assert char.classes[0].level == 1
 
     cls = Class(hit_die=8, features={1: [uuid4()]}, subclasses=[])

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -11,9 +11,14 @@ from schema.spell import Spell
 from schema.spellcasting import Spellcasting
 from schema.class_ import Class
 from schema.character import Character, CharacterClass
+from schema.feature import Feature
+from schema.item import Item
+from schema.background import Background
+from schema.race import Race
 from store.game_obj import GameObject
 from schema.factory import hydrate
 from store.game_obj import GameObject
+import random
 
 
 class DummyGameObject:
@@ -316,7 +321,54 @@ def test_load_items(monkeypatch):
     with pytest.raises(ValueError):
         cw.LiveCharacter.load_items(dummy_bad)
 
-    
+
+def test_livecharacter_rollables(monkeypatch):
+    feature_id = uuid4()
+    item_id = uuid4()
+    bg_id = uuid4()
+    race_id = uuid4()
+
+    feature = Feature(description="f", modifiers=[], rollables={"action": "1d6"})
+    item = Item(
+        category="weapon",
+        equipped=True,
+        modifiers=[],
+        attack_modifier=0,
+        damage_dice="1d4",
+        damage_modifier=0,
+        rollables={"bonus_action": "1d4"},
+    )
+    background = Background(description="bg", modifiers=[], rollables={})
+    race = Race(features=[], modifiers=[], rollables={})
+    feature_obj = GameObject(id=feature_id, name="FeatRoll", type="feature", data=feature.model_dump())
+    item_obj = GameObject(id=item_id, name="Sword", type="item", data=item.model_dump())
+    bg_obj = GameObject(id=bg_id, name="Acolyte", type="background", data=background.model_dump())
+    race_obj = GameObject(id=race_id, name="Elf", type="race", data=race.model_dump())
+
+    char = Character(
+        ac=10,
+        ability_scores={},
+        proficiency_bonus=2,
+        skills={},
+        background=bg_id,
+        race=race_id,
+        features=[feature_id],
+        inventory=[item_id],
+        classes=[],
+        rollables={},
+    )
+    char_obj = GameObject(name="Hero", type="character", data=char.model_dump())
+
+    objects = {feature_id: feature_obj, item_id: item_obj, bg_id: bg_obj, race_id: race_obj}
+
+    monkeypatch.setattr(live_object, "GameObjectDAO", lambda: DummyDAO(objects))
+    seq = iter([3, 2])
+    monkeypatch.setattr(random, "randint", lambda a, b: next(seq))
+    lc = cw.LiveCharacter(char_obj)
+    assert lc.rollables["action"]["FeatRoll"].roll(lc) == 3
+    assert lc.rollables["bonus_action"]["Sword"].roll(lc) == 2
+
+
 def test_livecharacter_init_feature_ids(monkeypatch):
     feature_id = uuid4()
 

--- a/wrappers/character_wrapper.py
+++ b/wrappers/character_wrapper.py
@@ -1,6 +1,7 @@
 from store.game_obj import GameObject
 from wrappers.live_object import LiveObject
 from schema.factory import hydrate
+from schema.rollable import Rollable
 from uuid import UUID
 from collections import deque
 import builtins
@@ -15,10 +16,21 @@ class LiveCharacter(LiveObject):
         self.features: list = []
         self.spells: dict = {}
         self.items: list = []
+        self.rollables: dict[str, dict[str, Rollable]] = getattr(self.data, "rollables", {})
         self.apply_background()
         self.load_features()
         self.load_spellcasting()
         self.load_items()
+
+    def _mount_rollables(self, name: str, rollables: dict[str, Rollable] | None) -> None:
+        if not rollables:
+            return
+        raw_rollables = self.raw.data.setdefault("rollables", {})
+        for action, roll in rollables.items():
+            raw_rollables.setdefault(action, {})[name] = roll.model_dump()
+            self.rollables.setdefault(action, {})[name] = roll
+        self.process_change()
+        self.rollables = self.data.rollables
 
     def _apply_modifier(self, mod, queue: deque | None = None, seen: set[UUID] | None = None) -> None:
         """Apply a single modifier to the character."""
@@ -89,6 +101,9 @@ class LiveCharacter(LiveObject):
                 # process them generically.
                 modifiers = getattr(hydrated, "modifiers", [])
 
+            name = getattr(game_obj, "name", str(current_id))
+            LiveCharacter._mount_rollables(self, name, getattr(hydrated, "rollables", {}))
+
             for mod in modifiers:
                 if mod.op == "grant" and mod.value not in seen:
                     queue.append(mod.value)
@@ -99,7 +114,9 @@ class LiveCharacter(LiveObject):
         background_id = getattr(getattr(self, "data", None), "background", None)
         if not background_id:
             return
-        background_obj = hydrate(self.dao.get_by_id(background_id))
+        bg_obj = self.dao.get_by_id(background_id)
+        background_obj = hydrate(bg_obj)
+        LiveCharacter._mount_rollables(self, getattr(bg_obj, "name", str(background_id)), getattr(background_obj, "rollables", {}))
         LiveCharacter._apply_modifiers(self, background_obj.modifiers)
         
     def _load_race(self) -> None:
@@ -107,10 +124,14 @@ class LiveCharacter(LiveObject):
         race_id = getattr(data, "race", None)
         if not race_id:
             return
-        race_obj = hydrate(self.dao.get_by_id(race_id))
+        race_go = self.dao.get_by_id(race_id)
+        race_obj = hydrate(race_go)
+        LiveCharacter._mount_rollables(self, getattr(race_go, "name", str(race_id)), getattr(race_obj, "rollables", {}))
         for feature_id in race_obj.features:
-            feature_obj = hydrate(self.dao.get_by_id(feature_id))
+            feature_go = self.dao.get_by_id(feature_id)
+            feature_obj = hydrate(feature_go)
             self.features.append(feature_obj)
+            LiveCharacter._mount_rollables(self, getattr(feature_go, "name", str(feature_id)), getattr(feature_obj, "rollables", {}))
         LiveCharacter._apply_modifiers(self, race_obj.modifiers)
 
     def load_features(self) -> None:
@@ -118,8 +139,10 @@ class LiveCharacter(LiveObject):
             data = getattr(self, "data", None)
             self.features = []
             for feature_id in getattr(data, "features", []):
-                feature_obj = hydrate(self.dao.get_by_id(feature_id))
+                feature_go = self.dao.get_by_id(feature_id)
+                feature_obj = hydrate(feature_go)
                 self.features.append(feature_obj)
+                LiveCharacter._mount_rollables(self, getattr(feature_go, "name", str(feature_id)), getattr(feature_obj, "rollables", {}))
             self._load_race()
         for feature_obj in self.features:
             LiveCharacter._apply_modifiers(self, feature_obj.modifiers)
@@ -130,15 +153,19 @@ class LiveCharacter(LiveObject):
         for class_entry in getattr(getattr(self, "data", {}), "classes", []):
             class_obj = self.dao.get_by_id(class_entry.class_id)
             hydrated_class = hydrate(class_obj)
+            LiveCharacter._mount_rollables(self, getattr(class_obj, "name", str(class_entry.class_id)), getattr(hydrated_class, "rollables", {}))
             spellcasting_id = getattr(hydrated_class, "spellcasting", None)
             if spellcasting_id:
                 sc_obj = self.dao.get_by_id(spellcasting_id)
                 hydrated_sc = hydrate(sc_obj)
+                LiveCharacter._mount_rollables(self, getattr(sc_obj, "name", str(spellcasting_id)), getattr(hydrated_sc, "rollables", {}))
                 spellcasting_map[class_obj.name] = hydrated_sc.model_dump()
-                spells_map[class_obj.name] = [
-                    hydrate(self.dao.get_by_id(spell_id))
-                    for spell_id in hydrated_sc.spell_list
-                ]
+                spells_map[class_obj.name] = []
+                for spell_id in hydrated_sc.spell_list:
+                    spell_obj = self.dao.get_by_id(spell_id)
+                    spell = hydrate(spell_obj)
+                    spells_map[class_obj.name].append(spell)
+                    LiveCharacter._mount_rollables(self, getattr(spell_obj, "name", str(spell_id)), getattr(spell, "rollables", {}))
         if spellcasting_map:
             self.raw.data.setdefault("spellcasting", {}).update(spellcasting_map)
             self.process_change()
@@ -148,8 +175,10 @@ class LiveCharacter(LiveObject):
         data = getattr(self, "data", None)
         self.items = []
         for item_id in getattr(data, "inventory", []):
-            item_obj = hydrate(self.dao.get_by_id(item_id))
+            item_go = self.dao.get_by_id(item_id)
+            item_obj = hydrate(item_go)
             self.items.append(item_obj)
+            LiveCharacter._mount_rollables(self, getattr(item_go, "name", str(item_id)), getattr(item_obj, "rollables", {}))
             if getattr(item_obj, "equipped", False):
                 LiveCharacter._apply_modifiers(self, item_obj.modifiers)
                 


### PR DESCRIPTION
## Summary
- collect rollables from background, race, features, items, and spells when building a LiveCharacter
- store character rollables by action type and source name
- test rollables mounted on LiveCharacter and character schema parsing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689611b153ec8323a82cd39feaa028f3