### PR TITLE
Initialize database schema automatically

### DIFF
--- a/store/dao.py
+++ b/store/dao.py
@@ -1,16 +1,27 @@
 import sqlite3
 import json
 from uuid import UUID
+from pathlib import Path
 
 from store.game_obj import GameObject
 from schema.factory import hydrate
 
 DB = "better5e_v1.db"
 
-def get_db_connection():
-    """Create a new database connection."""
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    """Initialize the database schema if it does not already exist."""
+    startup_sql = Path(__file__).with_name("startup.sql")
+    if startup_sql.exists():
+        with startup_sql.open("r", encoding="utf-8") as f:
+            conn.executescript(f.read())
+
+
+def get_db_connection() -> sqlite3.Connection:
+    """Create a new database connection and ensure the schema exists."""
     conn = sqlite3.connect(DB)
     conn.row_factory = sqlite3.Row
+    _ensure_schema(conn)
     return conn
 
 

--- a/store/startup.sql
+++ b/store/startup.sql
@@ -2,7 +2,6 @@ CREATE TABLE IF NOT EXISTS game_objects (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
     type TEXT NOT NULL,
-    data TEXT NOT NULL,
-    tags TEXT NOT NULL
+    data TEXT NOT NULL
 );
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -11,11 +11,8 @@ from store.game_obj import GameObject
 def setup_db(tmp_path, monkeypatch):
     db_file = tmp_path / "test.db"
     monkeypatch.setattr(dao, "DB", str(db_file))
+    # Establish a connection to trigger schema creation.
     conn = dao.get_db_connection()
-    conn.execute(
-        "CREATE TABLE game_objects (id TEXT PRIMARY KEY, name TEXT NOT NULL, type TEXT NOT NULL, data TEXT NOT NULL)"
-    )
-    conn.commit()
     conn.close()
     sqlite3.register_adapter(dict, lambda d: json.dumps(d))
 


### PR DESCRIPTION
## Summary
- Ensure SQLite schema exists by running startup script when opening a DB connection
- Remove unused `tags` column from startup SQL
- Adjust store tests to rely on automatic schema creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68962557a7148323a96f310e2b4170ca