### PR TITLE
Add tests for models and SQLite DAO

### DIFF
--- a/better5e/tests/test_dao.py
+++ b/better5e/tests/test_dao.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from uuid import uuid4
 
@@ -35,3 +35,26 @@ def test_dao_round_trip(tmp_path):
 
     # unknown id returns None
     assert dao.load_by_id(uuid4()) is None
+
+
+def test_dao_update_and_singleton(tmp_path):
+    """Saving the same object twice updates the record and DAO is a singleton."""
+    sqlite_dao.SingletonMeta._instances = {}
+    sqlite_dao.DAO.db_name = tmp_path / "test.db"
+
+    dao1 = sqlite_dao.DAO()
+    dao2 = sqlite_dao.DAO()
+    assert dao1 is dao2  # singleton behaviour
+
+    feature = go.Feature(name="Feat", desc="a")
+    dao1.save(feature)
+
+    # update description and resave
+    feature.desc = "updated"
+    dao1.save(feature)
+
+    loaded = dao1.load_by_id(feature.id)
+    assert loaded.desc == "updated"
+
+    # loading by a kind with no entries returns an empty list
+    assert dao1.load_by_kind("spell") == []

--- a/better5e/tests/test_models.py
+++ b/better5e/tests/test_models.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import better5e.models.game_object as go
+from better5e.models.enums import RechargeType, Op, ActionType
+from pydantic import TypeAdapter
+
+
+def test_feature_serialization_round_trip():
+    feature = go.Feature(
+        name="Darkvision",
+        desc="See in the dark",
+        uses_max=1,
+        recharge=RechargeType.LONG_REST,
+        modifiers=[go.Modifier(target="senses.darkvision", op=Op.SET, value=60)],
+        actions=[go.Action(action_type=ActionType.ACTION)],
+    )
+    adapter = TypeAdapter(go.AnyGameObj)
+    parsed = adapter.validate_json(feature.model_dump_json())
+    assert parsed == feature
+
+
+def test_default_lists_are_independent():
+    f1 = go.Feature(name="F1")
+    f2 = go.Feature(name="F2")
+    f1.actions.append(go.Action(action_type=ActionType.ACTION))
+    assert f2.actions == []
+
+
+def test_enum_values():
+    assert RechargeType.SHORT_REST.value == "short_rest"
+    assert Op.MUL.value == "mul"
+    assert ActionType.DAMAGE.value == "damage"


### PR DESCRIPTION
## Summary
- test Feature model serialization, defaults, and enum constants
- verify SQLite DAO save/load, updates, and singleton behavior

## Testing
- `pytest --cov=better5e.dao --cov=better5e.models --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68994b50ed688323abd5b09774868cbc