### PR TITLE
feat: introduce centralized theming

### DIFF
--- a/better5e/UI/main_screen/components/card_grid.py
+++ b/better5e/UI/main_screen/components/card_grid.py
@@ -1,6 +1,8 @@
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QWidget, QGridLayout, QFrame, QLabel, QVBoxLayout
 
+from better5e.UI.style.theme import add_shadow
+
 
 class CardGrid(QWidget):
     """Display placeholder cards in a three-up grid."""
@@ -14,9 +16,13 @@ class CardGrid(QWidget):
 
         for i, title in enumerate(titles):
             card = QFrame()
+            card.setObjectName("Card")
             card.setFrameShape(QFrame.Shape.StyledPanel)
             card.setMinimumSize(200, 220)
+            add_shadow(card)
             card_layout = QVBoxLayout(card)
-            card_layout.addWidget(QLabel(title, alignment=Qt.AlignmentFlag.AlignCenter))
+            card_layout.addWidget(
+                QLabel(title, alignment=Qt.AlignmentFlag.AlignCenter)
+            )
             row, col = divmod(i, 3)
             layout.addWidget(card, row, col)

--- a/better5e/UI/main_screen/components/dice_options.py
+++ b/better5e/UI/main_screen/components/dice_options.py
@@ -33,6 +33,7 @@ class DiceOptionsPanel(QWidget):
         layout.addWidget(self.mod_spin)
 
         self.roll_btn = QPushButton("Roll")
+        self.roll_btn.setProperty("class", "primary")
         layout.addWidget(self.roll_btn)
 
         self.roll_btn.clicked.connect(self.roll)

--- a/better5e/UI/main_screen/components/homebrew_panel.py
+++ b/better5e/UI/main_screen/components/homebrew_panel.py
@@ -1,6 +1,8 @@
 from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QPushButton
 
+from better5e.UI.style.theme import add_shadow
+
 
 class HomebrewPanel(QWidget):
     """Vertical list of buttons for creating homebrew objects."""
@@ -26,6 +28,7 @@ class HomebrewPanel(QWidget):
         for kind in kinds:
             btn = QPushButton(f"Create {kind.title()}")
             btn.clicked.connect(lambda _=False, k=kind: self.openHomebrew.emit(k))
+            add_shadow(btn)
             layout.addWidget(btn)
 
         layout.addStretch()

--- a/better5e/UI/main_screen/components/roll_history.py
+++ b/better5e/UI/main_screen/components/roll_history.py
@@ -1,8 +1,16 @@
+from PyQt6.QtGui import QFont
 from PyQt6.QtWidgets import QListWidget
+
+from better5e.UI.style import tokens
 
 
 class RollHistoryPanel(QListWidget):
     """List widget showing past dice rolls."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setFont(QFont(tokens.dark()["font_mono"], 12))
+        self.setAlternatingRowColors(True)
 
     def add_entry(self, text: str) -> None:
         """Append a roll result to the list."""

--- a/better5e/UI/main_screen/components/section_header.py
+++ b/better5e/UI/main_screen/components/section_header.py
@@ -9,6 +9,7 @@ class SectionHeader(QWidget):
 
     def __init__(self, title: str) -> None:
         super().__init__()
+        self.setProperty("class", "SectionHeader")
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
@@ -16,6 +17,7 @@ class SectionHeader(QWidget):
         layout.addStretch()
 
         button = QPushButton("See All >")
+        button.setProperty("class", "ghost")
         layout.addWidget(button)
         button.clicked.connect(self.seeAll.emit)
         self.button = button

--- a/better5e/UI/main_screen/main_screen.py
+++ b/better5e/UI/main_screen/main_screen.py
@@ -60,6 +60,7 @@ class MainScreen(BasePage):
         center_layout.addWidget(self.characters_header)
         center_layout.addWidget(CardGrid(["Character 1", "Character 2", "Character 3"]))
         self.characters_create = QPushButton("Create New")
+        self.characters_create.setProperty("class", "primary")
         self.characters_create.clicked.connect(self.createNewCharacter.emit)
         center_layout.addWidget(self.characters_create)
 
@@ -69,6 +70,7 @@ class MainScreen(BasePage):
         center_layout.addWidget(self.campaigns_header)
         center_layout.addWidget(CardGrid(["Campaign 1", "Campaign 2", "Campaign 3"]))
         self.campaigns_create = QPushButton("Create New")
+        self.campaigns_create.setProperty("class", "primary")
         self.campaigns_create.clicked.connect(self.createNewCampaign.emit)
         center_layout.addWidget(self.campaigns_create)
 

--- a/better5e/UI/style/theme.py
+++ b/better5e/UI/style/theme.py
@@ -1,0 +1,86 @@
+"""Theme application helpers for better5e.
+
+This module converts design tokens into Qt Style Sheet (QSS) and applies
+palette tweaks to a :class:`QApplication`.  A small utility for adding drop
+shadows to widgets is also provided.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from string import Template
+from typing import Dict
+
+from PyQt6.QtGui import QColor, QFont, QPalette
+from PyQt6.QtWidgets import QApplication, QWidget, QGraphicsDropShadowEffect
+
+THEME_QSS = Path(__file__).with_name("theme.qss")
+
+
+def _hex_to_rgb(value: str) -> str:
+    """Return ``"R, G, B"`` string from a hex colour value."""
+
+    value = value.lstrip("#")
+    r, g, b = int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16)
+    return f"{r}, {g}, {b}"
+
+
+def build_qss(tokens: Dict[str, object]) -> str:
+    """Generate QSS text for the given tokens."""
+
+    mapping = dict(tokens)
+    mapping["accent_rgb"] = _hex_to_rgb(str(tokens["accent"]))
+    template = Template(THEME_QSS.read_text(encoding="utf-8"))
+    return template.safe_substitute(mapping)
+
+
+def apply_style(app: QApplication, tokens: Dict[str, object]) -> None:
+    """Apply style sheet and palette based on *tokens* to *app*."""
+
+    app.setStyleSheet(build_qss(tokens))
+
+    palette = app.palette()
+    palette.setColor(QPalette.ColorRole.Window, QColor(str(tokens["bg"])))
+    palette.setColor(QPalette.ColorRole.WindowText, QColor(str(tokens["text"])))
+    palette.setColor(QPalette.ColorRole.Base, QColor(str(tokens["surface"])))
+    palette.setColor(
+        QPalette.ColorRole.AlternateBase, QColor(str(tokens["surfaceAlt"]))
+    )
+    palette.setColor(QPalette.ColorRole.Text, QColor(str(tokens["text"])))
+    palette.setColor(QPalette.ColorRole.Button, QColor(str(tokens["surface"])))
+    palette.setColor(QPalette.ColorRole.ButtonText, QColor(str(tokens["text"])))
+    palette.setColor(QPalette.ColorRole.Link, QColor(str(tokens["accent"])))
+    palette.setColor(
+        QPalette.ColorRole.ToolTipBase, QColor(str(tokens["surfaceAlt"]))
+    )
+    palette.setColor(QPalette.ColorRole.ToolTipText, QColor(str(tokens["text"])))
+    palette.setColor(
+        QPalette.ColorGroup.Disabled,
+        QPalette.ColorRole.Text,
+        QColor(str(tokens["mutedText"])),
+    )
+    palette.setColor(
+        QPalette.ColorGroup.Disabled,
+        QPalette.ColorRole.ButtonText,
+        QColor(str(tokens["mutedText"])),
+    )
+    app.setPalette(palette)
+
+    app.setFont(QFont(str(tokens["font_family"]), 13))
+
+
+def add_shadow(
+    widget: QWidget,
+    *,
+    blur: int = 24,
+    x: int = 0,
+    y: int = 4,
+    color: QColor | None = None,
+) -> None:
+    """Attach a subtle drop shadow effect to *widget*."""
+
+    effect = QGraphicsDropShadowEffect()
+    effect.setBlurRadius(blur)
+    effect.setOffset(x, y)
+    effect.setColor(color or QColor(0, 0, 0, 80))
+    widget.setGraphicsEffect(effect)

--- a/better5e/UI/style/theme.qss
+++ b/better5e/UI/style/theme.qss
@@ -1,0 +1,145 @@
+/* Core application styling */
+
+QMainWindow, QWidget {
+    background-color: $bg;
+    color: $text;
+    font-family: $font_family;
+    font-size: 13px;
+}
+
+/* Card container */
+QFrame#Card {
+    background-color: $surface;
+    border: 1px solid $border;
+    border-radius: ${radius_md}px;
+    padding: ${space_lg}px;
+    transition: background 0.2s, border 0.2s;
+}
+QFrame#Card:hover {
+    background-color: $surfaceAlt;
+    border: 1px solid $accent;
+}
+
+/* Buttons */
+QPushButton {
+    border-radius: ${radius_md}px;
+    padding: ${space_sm}px ${space_md}px;
+    border: 1px solid $border;
+    background-color: $surfaceAlt;
+    color: $text;
+}
+QPushButton:hover {
+    background-color: $surface;
+}
+QPushButton:pressed {
+    background-color: $surfaceAlt;
+}
+QPushButton:disabled {
+    color: $mutedText;
+    background-color: $surface;
+    border-color: $border;
+}
+
+QPushButton[class="primary"] {
+    background-color: $accent;
+    color: #ffffff;
+    border: none;
+}
+QPushButton[class="primary"]:hover {
+    background-color: $accentHover;
+}
+QPushButton[class="primary"]:pressed {
+    background-color: $accentHover;
+}
+
+QPushButton[class="secondary"] {
+    background-color: $surfaceAlt;
+    border: 1px solid $border;
+}
+
+QPushButton[class="ghost"] {
+    background-color: transparent;
+    border: none;
+    color: $accent;
+    padding: 0;
+}
+QPushButton[class="ghost"]:hover {
+    color: $accentHover;
+    text-decoration: underline;
+}
+
+/* Inputs */
+QLineEdit, QSpinBox, QComboBox {
+    background-color: $surface;
+    border: 1px solid $border;
+    border-radius: ${radius_md}px;
+    padding: ${space_sm}px;
+    selection-background-color: $accent;
+    selection-color: #ffffff;
+}
+QLineEdit:focus, QSpinBox:focus, QComboBox:focus {
+    border: 1px solid $accent;
+    outline: 2px solid rgba($accent_rgb, 0.6);
+}
+
+/* Lists and scroll areas */
+QListWidget, QListView, QScrollArea {
+    background-color: $surface;
+    border: 1px solid $border;
+    border-radius: ${radius_md}px;
+}
+QListWidget::item, QListView::item {
+    padding: ${space_sm}px;
+    border-radius: ${radius_sm}px;
+}
+QListWidget::item:selected, QListView::item:selected {
+    background-color: $accent;
+    color: #ffffff;
+}
+QListWidget::item:hover, QListView::item:hover {
+    background-color: $surfaceAlt;
+}
+QListWidget::item:alternate, QListView::item:alternate {
+    background-color: $surfaceAlt;
+}
+
+/* Scrollbars */
+QScrollBar:vertical {
+    background: $surface;
+    width: 10px;
+    margin: 0;
+}
+QScrollBar::handle:vertical {
+    background: $border;
+    border-radius: 5px;
+}
+QScrollBar::handle:vertical:hover {
+    background: $accent;
+}
+QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+    height: 0;
+    subcontrol-origin: margin;
+}
+
+/* Section headers */
+[class="SectionHeader"] QLabel {
+    font-size: 18px;
+    font-weight: bold;
+    color: $text;
+}
+[class="SectionHeader"] QPushButton {
+    qproperty-flat: true;
+}
+
+/* QGroupBox styling */
+QGroupBox {
+    border: 1px solid $border;
+    border-radius: ${radius_md}px;
+    margin-top: ${space_md}px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 0 ${space_sm}px;
+    color: $mutedText;
+}

--- a/better5e/UI/style/tokens.py
+++ b/better5e/UI/style/tokens.py
@@ -1,0 +1,80 @@
+"""Design tokens for the better5e UI.
+
+Provides color, spacing, radius and typography values used throughout
+application styling. Tokens are returned as plain dictionaries to keep the
+API simple and easily serialisable.  The :func:`dark` function exposes the
+primary dark theme palette while :func:`light` offers a lighter alternative
+for future expansion.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def _base() -> Dict[str, Any]:
+    """Return shared tokens across themes."""
+
+    return {
+        # Radii
+        "radius_sm": 6,
+        "radius_md": 10,
+        "radius_lg": 16,
+        # Spacing scale
+        "space_xs": 4,
+        "space_sm": 8,
+        "space_md": 12,
+        "space_lg": 16,
+        "space_xl": 24,
+        # Typography
+        "font_family": "Segoe UI, Roboto, Inter, Helvetica Neue, Arial",
+        "font_mono": "JetBrains Mono, Consolas, Menlo, monospace",
+    }
+
+
+def dark() -> Dict[str, Any]:
+    """Return tokens for the dark theme."""
+
+    t = _base()
+    t.update(
+        {
+            "bg": "#0f1115",
+            "surface": "#161a22",
+            "surfaceAlt": "#1c2230",
+            "text": "#e5e7eb",
+            "mutedText": "#9aa3b2",
+            "border": "#2a3242",
+            "accent": "#7c3aed",
+            "accentHover": "#8b5cf6",
+            "success": "#10b981",
+            "warning": "#f59e0b",
+            "error": "#ef4444",
+        }
+    )
+    return t
+
+
+def light() -> Dict[str, Any]:
+    """Return tokens for a light theme.
+
+    The palette mirrors :func:`dark` but with light surfaces.  This function is
+    primarily for completeness; the application defaults to the dark theme.
+    """
+
+    t = _base()
+    t.update(
+        {
+            "bg": "#ffffff",
+            "surface": "#f3f4f6",
+            "surfaceAlt": "#e5e7eb",
+            "text": "#111827",
+            "mutedText": "#6b7280",
+            "border": "#d1d5db",
+            "accent": "#7c3aed",
+            "accentHover": "#8b5cf6",
+            "success": "#059669",
+            "warning": "#d97706",
+            "error": "#dc2626",
+        }
+    )
+    return t

--- a/better5e/tests/test_style_theme.py
+++ b/better5e/tests/test_style_theme.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from PyQt6.QtWidgets import QApplication, QWidget
+import pytest
+
+from better5e.UI.style import tokens
+from better5e.UI.style import theme
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_tokens_dark_and_light():
+    dark = tokens.dark()
+    light = tokens.light()
+    assert dark["bg"] == "#0f1115"
+    assert light["bg"] == "#ffffff"
+    assert "font_mono" in dark
+
+
+def test_build_and_apply_style(qapp):
+    t = tokens.dark()
+    qss = theme.build_qss(t)
+    assert "QMainWindow" in qss
+    theme.apply_style(qapp, t)
+    assert qapp.styleSheet() == qss
+
+
+def test_add_shadow(qapp):
+    w = QWidget()
+    theme.add_shadow(w)
+    assert w.graphicsEffect() is not None

--- a/main.py
+++ b/main.py
@@ -1,13 +1,17 @@
 import sys
 
-from better5e.UI.core.app import App
-from better5e.UI.main_screen.main_screen import MainScreen
 from PyQt6.QtWidgets import QApplication
 
+from better5e.UI.core.app import App
+from better5e.UI.main_screen.main_screen import MainScreen
+from better5e.UI.style import tokens
+from better5e.UI.style.theme import apply_style
 
 
-def main () -> int:
+
+def main() -> int:
     qt = QApplication(sys.argv)
+    apply_style(qt, tokens.dark())
     return App(qt, MainScreen).run()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add design tokens and theme utilities for dark UI
- apply global styling and shadows to home screen widgets
- cover theming utilities with tests

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`
- `QT_QPA_PLATFORM=offscreen coverage run -m pytest`
- `coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_689a813f5b5c8323a29dd90be27816c9