### PR TITLE
feat: add roll history cards

### DIFF
--- a/better5e/UI/main_screen/components/roll_history.py
+++ b/better5e/UI/main_screen/components/roll_history.py
@@ -1,21 +1,137 @@
-from PyQt6.QtGui import QFont
-from PyQt6.QtWidgets import QListWidget
+from __future__ import annotations
 
-from better5e.UI.style import tokens
+import random
+import re
+from datetime import datetime
+
+from PyQt6.QtCore import Qt, QPoint, QSize
+from PyQt6.QtGui import QClipboard
+from PyQt6.QtWidgets import (
+    QApplication,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QHBoxLayout,
+    QVBoxLayout,
+    QWidget,
+    QMenu,
+)
+
+from better5e.UI.style.theme import add_shadow
+
+
+class RollCard(QWidget):
+    """Widget representing a single dice roll."""
+
+    def __init__(self, notation: str, total: int, details: str, ts: datetime) -> None:
+        super().__init__()
+        self.setObjectName("RollCard")
+        self.timestamp = ts
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(2)
+
+        row = QHBoxLayout()
+        row.setContentsMargins(0, 0, 0, 0)
+
+        notation_lbl = QLabel(notation)
+        notation_lbl.setObjectName("RollNotation")
+        total_lbl = QLabel(str(total))
+        total_lbl.setObjectName("RollTotal")
+
+        row.addWidget(notation_lbl)
+        row.addStretch(1)
+        row.addWidget(total_lbl, alignment=Qt.AlignmentFlag.AlignRight)
+        layout.addLayout(row)
+
+        meta_lbl = QLabel(details)
+        meta_lbl.setObjectName("RollMeta")
+        layout.addWidget(meta_lbl)
+
+        self.notation_label = notation_lbl
+        self.total_label = total_lbl
+        self.meta_label = meta_lbl
 
 
 class RollHistoryPanel(QListWidget):
     """List widget showing past dice rolls."""
 
+    _ROLL_RE = re.compile(r"(\d+)d(\d+)([+-]\d+) = (\d+) \(([^)]+)\)")
+
     def __init__(self) -> None:
         super().__init__()
-        self.setFont(QFont(tokens.dark()["font_mono"], 12))
-        self.setAlternatingRowColors(True)
+        self.setSpacing(8)
+        self.setAlternatingRowColors(False)
+        self.setSelectionMode(QListWidget.SelectionMode.SingleSelection)
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.customContextMenuRequested.connect(self._show_context_menu)
+        self.itemDoubleClicked.connect(self._reroll_item)
 
     def add_entry(self, text: str) -> None:
         """Append a roll result to the list."""
-        self.addItem(text)
+        match = self._ROLL_RE.fullmatch(text.strip())
+        if not match:
+            return
+
+        count, sides, mod, total, rolls_str = match.groups()
+        count_i, sides_i, mod_i = int(count), int(sides), int(mod)
+        total_i = int(total)
+        rolls = [int(r.strip()) for r in rolls_str.split(',')]
+        notation = f"{count_i}d{sides_i}{mod_i:+d}"
+        ts = datetime.now()
+        details = f"({', '.join(map(str, rolls))}) • {ts.strftime('%Y-%m-%d %H:%M')}"
+
+        card = RollCard(notation, total_i, details, ts)
+        if count_i == 1 and sides_i == 20 and rolls[0] == 20:
+            card.setProperty("crit", True)
+
+        add_shadow(card, blur=18, y=3)
+
+        item = QListWidgetItem()
+        item.setSizeHint(QSize(0, 72))
+        item.setData(Qt.ItemDataRole.UserRole, {
+            "notation": notation,
+            "total": total_i,
+            "rolls": rolls,
+            "mod": mod_i,
+            "sides": sides_i,
+            "count": count_i,
+        })
+        self.addItem(item)
+        self.setItemWidget(item, card)
 
     def clear_history(self) -> None:
         """Remove all roll entries."""
         self.clear()
+
+    # context menu ---------------------------------------------------------
+    def _show_context_menu(self, pos: QPoint) -> None:
+        item = self.itemAt(pos)
+        menu = QMenu(self)
+        copy_action = menu.addAction("Copy")
+        delete_action = menu.addAction("Delete")
+        menu.addSeparator()
+        clear_action = menu.addAction("Clear All")
+        action = menu.exec(self.viewport().mapToGlobal(pos))
+        if action == copy_action and item:
+            self._copy_item(item)
+        elif action == delete_action and item:
+            row = self.row(item)
+            self.takeItem(row)
+        elif action == clear_action:
+            self.clear_history()
+
+    def _copy_item(self, item: QListWidgetItem) -> None:
+        data = item.data(Qt.ItemDataRole.UserRole)
+        text = f"{data['notation']} = {data['total']} ({', '.join(map(str, data['rolls']))})"
+        QApplication.clipboard().setText(text, QClipboard.Mode.Clipboard)
+
+    # reroll ---------------------------------------------------------------
+    def _reroll_item(self, item: QListWidgetItem) -> None:
+        data = item.data(Qt.ItemDataRole.UserRole)
+        count, sides, mod = data["count"], data["sides"], data["mod"]
+        rolls = [random.randint(1, sides) for _ in range(count)]
+        total = sum(rolls) + mod
+        text = f"{count}d{sides}{mod:+d} = {total} ({', '.join(map(str, rolls))})"
+        self.add_entry(text)

--- a/better5e/UI/style/theme.qss
+++ b/better5e/UI/style/theme.qss
@@ -143,3 +143,31 @@ QGroupBox::title {
     padding: 0 ${space_sm}px;
     color: $mutedText;
 }
+
+/* Roll cards */
+QFrame#Card, QWidget#RollCard {
+    background-color: $surfaceAlt;
+    border: 1px solid $border;
+    border-radius: ${radius_md}px;
+    padding: 10px 12px;
+}
+QWidget#RollCard:hover {
+    border-color: $accent;
+}
+QLabel#RollNotation {
+    font-family: $font_mono;
+    font-size: 13px;
+    color: $text;
+}
+QLabel#RollTotal {
+    font-size: 20px;
+    font-weight: 700;
+    color: $text;
+}
+QLabel#RollMeta {
+    font-size: 12px;
+    color: $mutedText;
+}
+QWidget#RollCard[crit="true"] QLabel#RollTotal {
+    color: $success;
+}

--- a/better5e/tests/test_app.py
+++ b/better5e/tests/test_app.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+import os
 from PyQt6.QtWidgets import QApplication, QWidget
 import pytest
 
@@ -11,6 +12,7 @@ from better5e.UI.core.app import App
 
 @pytest.fixture(scope="session")
 def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     app = QApplication.instance()
     if app is None:
         app = QApplication([])

--- a/better5e/tests/test_style_theme.py
+++ b/better5e/tests/test_style_theme.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+import os
 from PyQt6.QtWidgets import QApplication, QWidget
 import pytest
 
@@ -12,6 +13,7 @@ from better5e.UI.style import theme
 
 @pytest.fixture(scope="session")
 def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     app = QApplication.instance()
     if app is None:
         app = QApplication([])

--- a/better5e/tests/test_ui_main_screen.py
+++ b/better5e/tests/test_ui_main_screen.py
@@ -4,9 +4,10 @@ import types
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+import os
 import random
 
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtWidgets import QApplication, QMenu
 import pytest
 
 from better5e.UI.main_screen.components.roll_history import RollHistoryPanel
@@ -19,6 +20,7 @@ from better5e.UI.main_screen.main_screen import MainScreen
 
 @pytest.fixture(scope="session")
 def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     app = QApplication.instance()
     if app is None:
         app = QApplication([])
@@ -27,6 +29,8 @@ def qapp():
 
 def test_dice_roll_updates_history(qapp, monkeypatch):
     history = RollHistoryPanel()
+    history.add_entry("bad")
+    assert history.count() == 0
     dice = DiceOptionsPanel()
     dice.rollMade.connect(history.add_entry)
     dice.die_box.setCurrentText("d4")
@@ -36,8 +40,50 @@ def test_dice_roll_updates_history(qapp, monkeypatch):
     monkeypatch.setattr(random, "randint", lambda a, b: next(seq))
     dice.roll()
     assert history.count() == 1
-    assert history.item(0).text() == "2d4+3 = 6 (1, 2)"
+    item = history.item(0)
+    card = history.itemWidget(item)
+    assert card.notation_label.text() == "2d4+3"
+    assert card.total_label.text() == "6"
+    assert "1, 2" in card.meta_label.text()
     history.clear_history()
+    assert history.count() == 0
+
+
+def test_roll_history_context_and_reroll(qapp, monkeypatch):
+    history = RollHistoryPanel()
+    history.add_entry("1d20+0 = 20 (20)")
+    item = history.item(0)
+    card = history.itemWidget(item)
+    assert card.property("crit") is True
+
+    history.show()
+    qapp.processEvents()
+    pos = history.visualItemRect(item).center()
+
+    def fake_exec_copy(menu, _):
+        return menu.actions()[0]
+
+    monkeypatch.setattr(QMenu, "exec", fake_exec_copy)
+    history._show_context_menu(pos)
+    assert QApplication.clipboard().text() == "1d20+0 = 20 (20)"
+
+    seq = iter([5])
+    monkeypatch.setattr(random, "randint", lambda a, b: next(seq))
+    history._reroll_item(item)
+    assert history.count() == 2
+
+    def fake_exec_delete(menu, _):
+        return menu.actions()[1]
+
+    monkeypatch.setattr(QMenu, "exec", fake_exec_delete)
+    history._show_context_menu(pos)
+    assert history.count() == 1
+
+    def fake_exec_clear(menu, _):
+        return menu.actions()[3]
+
+    monkeypatch.setattr(QMenu, "exec", fake_exec_clear)
+    history._show_context_menu(pos)
     assert history.count() == 0
 
 


### PR DESCRIPTION
## Summary
- add RollCard widget and render history entries as styled cards
- implement copy/delete/clear and reroll actions in roll history panel
- theme roll cards in QSS and update tests for offscreen Qt

## Testing
- `coverage run -m pytest`
- `coverage report`


------
https://chatgpt.com/codex/tasks/task_e_689a84a387e48323819109ef906f332c