### PR TITLE
feat: add modern dice pad widget

### DIFF
--- a/better5e/UI/main_screen/components/dice_options.py
+++ b/better5e/UI/main_screen/components/dice_options.py
@@ -12,6 +12,8 @@ from PyQt6.QtWidgets import (
     QPushButton,
     QToolButton,
     QLineEdit,
+    QSizePolicy,
+    QSpacerItem,
 )
 
 from better5e.UI.main_screen.components.die_button import DieButton
@@ -82,15 +84,13 @@ class DiceOptionsPanel(QWidget):
     def __init__(self) -> None:
         super().__init__()
 
-        main = QHBoxLayout(self)
-        main.setSpacing(12)
-
-        left_col = QVBoxLayout()
-        main.addLayout(left_col, 1)
+        root = QVBoxLayout(self)
+        root.setContentsMargins(8, 8, 8, 8)
+        root.setSpacing(12)
 
         grid = QGridLayout()
         grid.setSpacing(6)
-        left_col.addLayout(grid)
+        root.addLayout(grid)
 
         self.dice: Dict[int, DieButton] = {}
         order = [4, 6, 8, 10, 12, 20, 100]
@@ -102,10 +102,9 @@ class DiceOptionsPanel(QWidget):
             self.dice[sides] = btn
 
         self.mod_ctrl = ModifierControl()
-        left_col.addWidget(self.mod_ctrl)
+        root.addWidget(self.mod_ctrl)
 
-        actions = QVBoxLayout()
-        main.addLayout(actions)
+        root.addItem(QSpacerItem(0, 0, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding))
 
         reset_btn = QPushButton("Reset")
         reset_btn.setObjectName("ResetBtn")
@@ -115,9 +114,12 @@ class DiceOptionsPanel(QWidget):
         roll_btn.setProperty("class", "primary")
         roll_btn.setEnabled(False)
 
-        actions.addWidget(reset_btn)
-        actions.addWidget(roll_btn)
-        actions.addStretch(1)
+        for b in (reset_btn, roll_btn):
+            b.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+            b.setMinimumHeight(44)
+
+        root.addWidget(reset_btn)
+        root.addWidget(roll_btn)
 
         reset_btn.clicked.connect(self.reset)
         roll_btn.clicked.connect(self.roll)

--- a/better5e/UI/main_screen/components/dice_options.py
+++ b/better5e/UI/main_screen/components/dice_options.py
@@ -1,55 +1,160 @@
-import random
+from __future__ import annotations
 
-from PyQt6.QtCore import pyqtSignal
-from PyQt6.QtGui import QKeySequence, QShortcut
+from typing import Dict, Tuple
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QIntValidator, QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QWidget,
-    QComboBox,
-    QSpinBox,
-    QPushButton,
+    QGridLayout,
+    QVBoxLayout,
     QHBoxLayout,
+    QPushButton,
+    QToolButton,
+    QLineEdit,
 )
 
+from better5e.UI.main_screen.components.die_button import DieButton
 
-class DiceOptionsPanel(QWidget):
-    """Controls for choosing dice, count and modifier."""
 
-    rollMade = pyqtSignal(str)
+class ModifierControl(QWidget):
+    """Numeric modifier widget with +/− buttons."""
+
+    valueChanged = pyqtSignal(int)
 
     def __init__(self) -> None:
         super().__init__()
+        self.setObjectName("ModifierControl")
+        self._val = 0
+
+        minus = QToolButton()
+        minus.setText("-")
+        plus = QToolButton()
+        plus.setText("+")
+        edit = QLineEdit("0")
+        edit.setValidator(QIntValidator(-999, 999, self))
+        edit.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
         layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        layout.addWidget(minus)
+        layout.addWidget(edit, 1)
+        layout.addWidget(plus)
 
-        self.die_box = QComboBox()
-        self.die_box.addItems(["d4", "d6", "d8", "d10", "d12", "d20", "d100"])
-        layout.addWidget(self.die_box)
+        minus.clicked.connect(lambda: self.setValue(self._val - 1))
+        plus.clicked.connect(lambda: self.setValue(self._val + 1))
+        edit.textChanged.connect(self._on_text_changed)
 
-        self.count_spin = QSpinBox()
-        self.count_spin.setRange(1, 10)
-        layout.addWidget(self.count_spin)
+        self.minus = minus
+        self.plus = plus
+        self.edit = edit
 
-        self.mod_spin = QSpinBox()
-        self.mod_spin.setRange(-20, 20)
-        layout.addWidget(self.mod_spin)
+    def _on_text_changed(self, text: str) -> None:
+        try:
+            val = int(text)
+        except ValueError:
+            val = 0
+        self._val = max(-999, min(999, val))
+        if self.edit.text() != str(self._val):
+            self.edit.setText(str(self._val))
+        self.valueChanged.emit(self._val)
 
-        self.roll_btn = QPushButton("Roll")
-        self.roll_btn.setProperty("class", "primary")
-        layout.addWidget(self.roll_btn)
+    def setValue(self, value: int) -> None:
+        value = max(-999, min(999, value))
+        if value == self._val:
+            return
+        self._val = value
+        self.edit.setText(str(value))
+        self.valueChanged.emit(value)
 
-        self.roll_btn.clicked.connect(self.roll)
+    @property
+    def value(self) -> int:
+        return self._val
 
-        shortcut = QShortcut(QKeySequence("R"), self)
-        shortcut.activated.connect(self.roll)
-        self._shortcut = shortcut  # keep reference
+
+class DiceOptionsPanel(QWidget):
+    """Modern dice pad allowing multiple dice selection."""
+
+    rollRequested = pyqtSignal(dict, int)
+    resetRequested = pyqtSignal()
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        main = QHBoxLayout(self)
+        main.setSpacing(12)
+
+        left_col = QVBoxLayout()
+        main.addLayout(left_col, 1)
+
+        grid = QGridLayout()
+        grid.setSpacing(6)
+        left_col.addLayout(grid)
+
+        self.dice: Dict[int, DieButton] = {}
+        order = [4, 6, 8, 10, 12, 20, 100]
+        positions = [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2)]
+        for pos, sides in zip(positions, order):
+            btn = DieButton(sides)
+            btn.countChanged.connect(self._update_roll_enabled)
+            grid.addWidget(btn, *pos)
+            self.dice[sides] = btn
+
+        self.mod_ctrl = ModifierControl()
+        left_col.addWidget(self.mod_ctrl)
+
+        actions = QVBoxLayout()
+        main.addLayout(actions)
+
+        reset_btn = QPushButton("Reset")
+        reset_btn.setObjectName("ResetBtn")
+        reset_btn.setProperty("class", "secondary")
+        roll_btn = QPushButton("Roll")
+        roll_btn.setObjectName("RollBtn")
+        roll_btn.setProperty("class", "primary")
+        roll_btn.setEnabled(False)
+
+        actions.addWidget(reset_btn)
+        actions.addWidget(roll_btn)
+        actions.addStretch(1)
+
+        reset_btn.clicked.connect(self.reset)
+        roll_btn.clicked.connect(self.roll)
+
+        QShortcut(QKeySequence("R"), self, activated=self.roll)
+        QShortcut(QKeySequence("Esc"), self, activated=self.reset)
+
+        self.roll_btn = roll_btn
+        self.reset_btn = reset_btn
+
+    # utilities ----------------------------------------------------------
+    def _update_roll_enabled(self, *_: int) -> None:
+        total = sum(btn.count for btn in self.dice.values())
+        self.roll_btn.setEnabled(total > 0)
+
+    def reset(self) -> None:
+        for btn in self.dice.values():
+            btn.count = 0
+        self.mod_ctrl.setValue(0)
+        self._update_roll_enabled()
+        self.resetRequested.emit()
 
     def roll(self) -> None:
-        """Roll dice according to current settings and emit result string."""
-        sides = int(self.die_box.currentText()[1:])
-        count = self.count_spin.value()
-        mod = self.mod_spin.value()
-        results = [random.randint(1, sides) for _ in range(count)]
-        total = sum(results) + mod
-        msg = (
-            f"{count}d{sides}{mod:+d} = {total} (" + ", ".join(map(str, results)) + ")"
-        )
-        self.rollMade.emit(msg)
+        dice = {sides: btn.count for sides, btn in self.dice.items() if btn.count}
+        if not dice:
+            return
+        self.rollRequested.emit(dice, self.mod_ctrl.value)
+
+    def state(self) -> Tuple[Dict[int, int], int]:
+        dice = {sides: btn.count for sides, btn in self.dice.items() if btn.count}
+        return dice, self.mod_ctrl.value
+
+    def get_notation(self) -> str:
+        dice, mod = self.state()
+        parts = [f"{cnt}d{sides}" for sides, cnt in dice.items()]
+        notation = " + ".join(parts)
+        if mod:
+            sign = "+" if mod > 0 else "-"
+            notation = f"{notation} {sign} {abs(mod)}" if notation else f"{mod}"
+        return notation.strip()

--- a/better5e/UI/main_screen/components/dice_options.py
+++ b/better5e/UI/main_screen/components/dice_options.py
@@ -19,6 +19,9 @@ from PyQt6.QtWidgets import (
 from better5e.UI.main_screen.components.die_button import DieButton
 
 
+DICE_SIDES = [2, 4, 6, 8, 10, 12, 20, 100]
+
+
 class ModifierControl(QWidget):
     """Numeric modifier widget with +/− buttons."""
 
@@ -89,17 +92,18 @@ class DiceOptionsPanel(QWidget):
         root.setSpacing(12)
 
         grid = QGridLayout()
-        grid.setSpacing(6)
+        grid.setHorizontalSpacing(12)
+        grid.setVerticalSpacing(12)
         root.addLayout(grid)
 
-        self.dice: Dict[int, DieButton] = {}
-        order = [4, 6, 8, 10, 12, 20, 100]
-        positions = [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2)]
-        for pos, sides in zip(positions, order):
+        self.die_buttons: dict[int, DieButton] = {}
+        for i, sides in enumerate(DICE_SIDES):
             btn = DieButton(sides)
+            btn.setToolTip("Coin flip (d2)" if sides == 2 else f"d{sides}")
             btn.countChanged.connect(self._update_roll_enabled)
-            grid.addWidget(btn, *pos)
-            self.dice[sides] = btn
+            row, col = divmod(i, 4)
+            grid.addWidget(btn, row, col)
+            self.die_buttons[sides] = btn
 
         self.mod_ctrl = ModifierControl()
         root.addWidget(self.mod_ctrl)
@@ -132,24 +136,24 @@ class DiceOptionsPanel(QWidget):
 
     # utilities ----------------------------------------------------------
     def _update_roll_enabled(self, *_: int) -> None:
-        total = sum(btn.count for btn in self.dice.values())
+        total = sum(btn.count for btn in self.die_buttons.values())
         self.roll_btn.setEnabled(total > 0)
 
     def reset(self) -> None:
-        for btn in self.dice.values():
+        for btn in self.die_buttons.values():
             btn.count = 0
         self.mod_ctrl.setValue(0)
         self._update_roll_enabled()
         self.resetRequested.emit()
 
     def roll(self) -> None:
-        dice = {sides: btn.count for sides, btn in self.dice.items() if btn.count}
+        dice = {sides: btn.count for sides, btn in self.die_buttons.items() if btn.count}
         if not dice:
             return
         self.rollRequested.emit(dice, self.mod_ctrl.value)
 
     def state(self) -> Tuple[Dict[int, int], int]:
-        dice = {sides: btn.count for sides, btn in self.dice.items() if btn.count}
+        dice = {sides: btn.count for sides, btn in self.die_buttons.items() if btn.count}
         return dice, self.mod_ctrl.value
 
     def get_notation(self) -> str:

--- a/better5e/UI/main_screen/components/die_button.py
+++ b/better5e/UI/main_screen/components/die_button.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import QLabel, QPushButton, QGridLayout
+
+
+class DieButton(QPushButton):
+    """Button representing a single die type with a count badge."""
+
+    countChanged = pyqtSignal(int)
+
+    def __init__(self, sides: int) -> None:
+        super().__init__(f"d{sides}")
+        self.setObjectName("DieButton")
+        self.setProperty("class", "die")
+        self.sides = sides
+        self._count = 0
+
+        badge = QLabel("0", self)
+        badge.setObjectName("DieBadge")
+        layout = QGridLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(badge, 0, 0, alignment=Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignRight)
+        badge.hide()
+        self.badge = badge
+
+    # count property -----------------------------------------------------
+    @property
+    def count(self) -> int:
+        return self._count
+
+    @count.setter
+    def count(self, value: int) -> None:
+        value = max(0, min(99, value))
+        if self._count == value:
+            return
+        self._count = value
+        self.badge.setText("9+" if value > 9 else str(value))
+        self.badge.setVisible(value > 0)
+        self.countChanged.emit(value)
+
+    # events -------------------------------------------------------------
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.count += 1
+            event.accept()
+            return
+        if event.button() == Qt.MouseButton.RightButton:
+            self.count -= 1
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def wheelEvent(self, event) -> None:  # type: ignore[override]
+        delta = event.angleDelta().y()
+        if delta > 0:
+            self.count += 1
+        elif delta < 0:
+            self.count -= 1
+        event.accept()

--- a/better5e/UI/main_screen/components/roll_history.py
+++ b/better5e/UI/main_screen/components/roll_history.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import random
-import re
 from datetime import datetime
 
 from PyQt6.QtCore import Qt, QPoint, QSize
@@ -80,8 +79,6 @@ class RollCard(QWidget):
 class RollHistoryPanel(QListWidget):
     """List widget showing past dice rolls."""
 
-    _ROLL_RE = re.compile(r"(\d+)d(\d+)([+-]\d+) = (\d+) \(([^)]+)\)")
-
     def __init__(self) -> None:
         super().__init__()
         self.setSpacing(8)
@@ -91,21 +88,38 @@ class RollHistoryPanel(QListWidget):
         self.customContextMenuRequested.connect(self._show_context_menu)
         self.itemDoubleClicked.connect(self._reroll_item)
 
+    def _parse_notation(self, notation: str) -> tuple[dict[int, int], int]:
+        dice: dict[int, int] = {}
+        mod = 0
+        parts = notation.replace("-", "+-").split("+")
+        for part in parts:
+            part = part.strip()
+            if not part:
+                continue
+            if "d" in part:
+                count_str, sides_str = part.split("d", 1)
+                dice[int(sides_str)] = dice.get(int(sides_str), 0) + int(count_str)
+            else:
+                mod += int(part)
+        return dice, mod
+
     def add_entry(self, text: str) -> None:
         """Append a roll result to the list."""
-        match = self._ROLL_RE.fullmatch(text.strip())
-        if not match:
+        text = text.strip()
+        if " = " not in text or "(" not in text or not text.endswith(")"):
             return
-
-        count, sides, mod, total, rolls_str = match.groups()
-        count_i, sides_i, mod_i = int(count), int(sides), int(mod)
-        total_i = int(total)
-        rolls = [int(r.strip()) for r in rolls_str.split(',')]
-        notation = f"{count_i}d{sides_i}{mod_i:+d}"
+        notation_part, rest = text.split(" = ", 1)
+        total_part, rolls_part = rest.split(" (", 1)
+        try:
+            total_i = int(total_part)
+        except ValueError:
+            return
+        rolls = [int(r.strip()) for r in rolls_part[:-1].split(",")]
+        dice_map, mod = self._parse_notation(notation_part)
         ts = datetime.now()
 
-        card = RollCard(notation, total_i, rolls, ts)
-        if count_i == 1 and sides_i == 20 and rolls[0] == 20:
+        card = RollCard(notation_part, total_i, rolls, ts)
+        if dice_map.get(20) == 1 and len(rolls) == sum(dice_map.values()) and rolls[0] == 20:
             card.setProperty("crit", True)
 
         add_shadow(card, blur=18, y=3)
@@ -113,12 +127,11 @@ class RollHistoryPanel(QListWidget):
         item = QListWidgetItem()
         item.setSizeHint(QSize(0, 72))
         item.setData(Qt.ItemDataRole.UserRole, {
-            "notation": notation,
+            "notation": notation_part,
             "total": total_i,
             "rolls": rolls,
-            "mod": mod_i,
-            "sides": sides_i,
-            "count": count_i,
+            "mod": mod,
+            "dice": dice_map,
         })
         self.addItem(item)
         self.setItemWidget(item, card)
@@ -152,8 +165,11 @@ class RollHistoryPanel(QListWidget):
     # reroll ---------------------------------------------------------------
     def _reroll_item(self, item: QListWidgetItem) -> None:
         data = item.data(Qt.ItemDataRole.UserRole)
-        count, sides, mod = data["count"], data["sides"], data["mod"]
-        rolls = [random.randint(1, sides) for _ in range(count)]
+        dice: dict[int, int] = data["dice"]
+        mod = data["mod"]
+        rolls: list[int] = []
+        for sides, count in dice.items():
+            rolls.extend(random.randint(1, sides) for _ in range(count))
         total = sum(rolls) + mod
-        text = f"{count}d{sides}{mod:+d} = {total} ({', '.join(map(str, rolls))})"
+        text = f"{data['notation']} = {total} ({', '.join(map(str, rolls))})"
         self.add_entry(text)

--- a/better5e/UI/main_screen/main_screen.py
+++ b/better5e/UI/main_screen/main_screen.py
@@ -1,3 +1,5 @@
+import random
+
 from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtWidgets import (
     QHBoxLayout,
@@ -40,7 +42,7 @@ class MainScreen(BasePage):
         self.roll_history = RollHistoryPanel()
         left.addWidget(self.roll_history)
         self.dice_panel = DiceOptionsPanel()
-        self.dice_panel.rollMade.connect(self.roll_history.add_entry)
+        self.dice_panel.rollRequested.connect(self._on_roll_requested)
         left.addWidget(self.dice_panel)
         left.setStretch(0, 1)
         columns.addLayout(left)
@@ -80,3 +82,20 @@ class MainScreen(BasePage):
         self.homebrew_panel = HomebrewPanel()
         self.homebrew_panel.openHomebrew.connect(self.openHomebrew.emit)
         columns.addWidget(self.homebrew_panel)
+
+    # roll handling -----------------------------------------------------
+    def _on_roll_requested(self, dice: dict[int, int], modifier: int) -> None:
+        rolls: list[int] = []
+        notation_parts: list[str] = []
+        total = modifier
+        for sides, count in dice.items():
+            part_rolls = [random.randint(1, sides) for _ in range(count)]
+            rolls.extend(part_rolls)
+            total += sum(part_rolls)
+            notation_parts.append(f"{count}d{sides}")
+        notation = " + ".join(notation_parts)
+        if modifier:
+            sign = "+" if modifier > 0 else "-"
+            notation = f"{notation} {sign} {abs(modifier)}" if notation else f"{modifier}"
+        text = f"{notation.strip()} = {total} ({', '.join(map(str, rolls))})"
+        self.roll_history.add_entry(text)

--- a/better5e/UI/style/theme.qss
+++ b/better5e/UI/style/theme.qss
@@ -215,5 +215,5 @@ QWidget#ModifierControl QToolButton {
 QWidget#ModifierControl QToolButton:hover { border-color: $accent; }
 
 /* Actions */
-QPushButton#ResetBtn { width: 100%; margin-bottom: 8px; }
-QPushButton#RollBtn { width: 100%; }
+QPushButton#ResetBtn { margin-top: 8px; }
+QPushButton#RollBtn  { margin-top: 6px; }

--- a/better5e/UI/style/theme.qss
+++ b/better5e/UI/style/theme.qss
@@ -179,3 +179,41 @@ QLabel[class~="chip"] {
     background: rgba(255,255,255,0.04);
     font-size: 11px;
 }
+
+/* Dice buttons */
+QPushButton[class~="die"] {
+  min-width: 72px; min-height: 44px;
+  padding: 8px 14px;
+  border-radius: 12px;
+  background: $surfaceAlt;
+  border: 1px solid $border;
+  font-weight: 600;
+}
+QPushButton[class~="die"]:hover { border-color: $accent; }
+QPushButton[class~="die"]:pressed { transform: translateY(1px); }
+
+QPushButton[class~="die"] QLabel#DieBadge {
+  background: $accent;
+  color: white;
+  border-radius: 9px;
+  min-width: 18px; min-height: 18px;
+  padding: 0 5px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+/* Modifier control */
+QWidget#ModifierControl { background: transparent; }
+QWidget#ModifierControl QLineEdit {
+  min-height: 36px; font-size: 14px; text-align: center;
+  border-radius: 10px; border: 1px solid $border; background: $surfaceAlt; color: $text;
+}
+QWidget#ModifierControl QToolButton {
+  min-width: 36px; min-height: 36px;
+  border-radius: 10px; border: 1px solid $border; background: $surfaceAlt; color: $text;
+}
+QWidget#ModifierControl QToolButton:hover { border-color: $accent; }
+
+/* Actions */
+QPushButton#ResetBtn { width: 100%; margin-bottom: 8px; }
+QPushButton#RollBtn { width: 100%; }

--- a/better5e/tests/test_dice_pad.py
+++ b/better5e/tests/test_dice_pad.py
@@ -1,0 +1,110 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from PyQt6.QtCore import Qt, QPointF, QPoint
+from PyQt6.QtGui import QMouseEvent, QWheelEvent
+from PyQt6.QtWidgets import QApplication
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from better5e.UI.main_screen.components.die_button import DieButton
+from better5e.UI.main_screen.components.dice_options import DiceOptionsPanel, ModifierControl
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _mouse_press(btn: DieButton, button: Qt.MouseButton) -> None:
+    ev = QMouseEvent(
+        QMouseEvent.Type.MouseButtonPress,
+        QPointF(),
+        QPointF(),
+        button,
+        button,
+        Qt.KeyboardModifier.NoModifier,
+    )
+    btn.mousePressEvent(ev)
+
+
+def test_die_button_interactions(qapp):
+    btn = DieButton(6)
+    assert btn.count == 0
+    _mouse_press(btn, Qt.MouseButton.LeftButton)
+    assert btn.count == 1 and not btn.badge.isHidden()
+    _mouse_press(btn, Qt.MouseButton.RightButton)
+    assert btn.count == 0 and btn.badge.isHidden()
+    _mouse_press(btn, Qt.MouseButton.MiddleButton)
+    assert btn.count == 0
+    wheel_up = QWheelEvent(
+        QPointF(),
+        QPointF(),
+        QPoint(),
+        QPoint(0, 120),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+    btn.wheelEvent(wheel_up)
+    assert btn.count == 1
+    wheel_down = QWheelEvent(
+        QPointF(),
+        QPointF(),
+        QPoint(),
+        QPoint(0, -120),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+    btn.wheelEvent(wheel_down)
+    assert btn.count == 0
+    wheel_zero = QWheelEvent(
+        QPointF(),
+        QPointF(),
+        QPoint(),
+        QPoint(0, 0),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+    btn.wheelEvent(wheel_zero)
+    assert btn.count == 0
+    btn.count = 10
+    assert btn.badge.text() == "9+"
+
+
+def test_modifier_control(qapp):
+    ctrl = ModifierControl()
+    values = []
+    ctrl.valueChanged.connect(values.append)
+    ctrl.setValue(5)
+    ctrl.minus.click()
+    ctrl.plus.click()
+    ctrl.setValue(1000)
+    ctrl.edit.setText("abc")
+    assert ctrl.value == 0
+    assert values[0] == 5
+
+
+def test_notation_and_state(qapp):
+    panel = DiceOptionsPanel()
+    assert not panel.roll_btn.isEnabled()
+    panel.dice[8].count = 2
+    panel.mod_ctrl.setValue(-5)
+    assert panel.roll_btn.isEnabled()
+    assert panel.get_notation() == "2d8 - 5"
+    assert panel.state() == ({8: 2}, -5)
+    panel.reset()
+    assert panel.get_notation() == ""
+    assert not panel.roll_btn.isEnabled()
+    panel.roll()  # no dice selected: early return

--- a/better5e/tests/test_dice_pad.py
+++ b/better5e/tests/test_dice_pad.py
@@ -99,7 +99,7 @@ def test_modifier_control(qapp):
 def test_notation_and_state(qapp):
     panel = DiceOptionsPanel()
     assert not panel.roll_btn.isEnabled()
-    panel.dice[8].count = 2
+    panel.die_buttons[8].count = 2
     panel.mod_ctrl.setValue(-5)
     assert panel.roll_btn.isEnabled()
     assert panel.get_notation() == "2d8 - 5"

--- a/better5e/tests/test_ui_main_screen.py
+++ b/better5e/tests/test_ui_main_screen.py
@@ -33,25 +33,44 @@ def test_dice_roll_updates_history(qapp, monkeypatch):
     history.add_entry("bad")
     assert history.count() == 0
     dice = DiceOptionsPanel()
-    dice.rollMade.connect(history.add_entry)
-    dice.die_box.setCurrentText("d4")
-    dice.count_spin.setValue(2)
-    dice.mod_spin.setValue(3)
-    seq = iter([1, 2])
+
+    def handler(dice_map, mod):
+        rolls: list[int] = []
+        total = mod
+        parts = []
+        for sides, count in dice_map.items():
+            r = [random.randint(1, sides) for _ in range(count)]
+            rolls.extend(r)
+            total += sum(r)
+            parts.append(f"{count}d{sides}")
+        notation = " + ".join(parts)
+        if mod:
+            sign = "+" if mod > 0 else "-"
+            notation = f"{notation} {sign} {abs(mod)}" if notation else f"{mod}"
+        history.add_entry(f"{notation} = {total} ({', '.join(map(str, rolls))})")
+
+    dice.rollRequested.connect(handler)
+    dice.dice[4].count = 2
+    dice.dice[6].count = 1
+    dice.mod_ctrl.setValue(3)
+    seq = iter([1, 2, 5])
     monkeypatch.setattr(random, "randint", lambda a, b: next(seq))
     dice.roll()
     assert history.count() == 1
     item = history.item(0)
     card = history.itemWidget(item)
-    assert card.notation_label.text() == "2d4+3"
-    assert card.total_label.text() == "6"
-    assert [lab.text() for lab in card.roll_labels] == ["1", "2"]
+    assert card.notation_label.text() == "2d4 + 1d6 + 3"
+    assert card.total_label.text() == "11"
+    assert [lab.text() for lab in card.roll_labels] == ["1", "2", "5"]
     history.clear_history()
     assert history.count() == 0
 
 
 def test_roll_history_context_and_reroll(qapp, monkeypatch):
     history = RollHistoryPanel()
+    assert history._parse_notation("+3") == ({}, 3)
+    history.add_entry("1d4 = bad (1)")
+    assert history.count() == 0
     history.add_entry("1d20+0 = 20 (20)")
     item = history.item(0)
     card = history.itemWidget(item)
@@ -86,6 +105,14 @@ def test_roll_history_context_and_reroll(qapp, monkeypatch):
     monkeypatch.setattr(QMenu, "exec", fake_exec_clear)
     history._show_context_menu(pos)
     assert history.count() == 0
+
+    def fake_exec_none(menu, _):
+        return None
+
+    history.add_entry("1d4 = 2 (2)")
+    monkeypatch.setattr(QMenu, "exec", fake_exec_none)
+    history._show_context_menu(history.visualItemRect(history.item(0)).center())
+    assert history.count() == 1
 
 
 def test_section_header_and_card_grid(qapp):
@@ -130,13 +157,16 @@ def test_main_screen_signal_propagation(qapp, monkeypatch):
     assert signals == ["see_chars", "new_char", "see_camps", "new_camp", "class"]
 
     # roll wiring
-    seq = iter([4])
+    seq = iter([4, 3])
     monkeypatch.setattr(random, "randint", lambda a, b: next(seq))
-    screen.dice_panel.count_spin.setValue(1)
-    screen.dice_panel.mod_spin.setValue(0)
-    screen.dice_panel.die_box.setCurrentText("d6")
+    screen.dice_panel.dice[6].count = 1
+    screen.dice_panel.mod_ctrl.setValue(0)
     screen.dice_panel.roll()
-    assert screen.roll_history.count() == 1
+    screen.dice_panel.dice[6].count = 0
+    screen.dice_panel.dice[4].count = 1
+    screen.dice_panel.mod_ctrl.setValue(2)
+    screen.dice_panel.roll()
+    assert screen.roll_history.count() == 2
 
 
 def test_fmt_time_variants():

--- a/better5e/tests/test_ui_main_screen.py
+++ b/better5e/tests/test_ui_main_screen.py
@@ -50,8 +50,8 @@ def test_dice_roll_updates_history(qapp, monkeypatch):
         history.add_entry(f"{notation} = {total} ({', '.join(map(str, rolls))})")
 
     dice.rollRequested.connect(handler)
-    dice.dice[4].count = 2
-    dice.dice[6].count = 1
+    dice.die_buttons[4].count = 2
+    dice.die_buttons[6].count = 1
     dice.mod_ctrl.setValue(3)
     seq = iter([1, 2, 5])
     monkeypatch.setattr(random, "randint", lambda a, b: next(seq))
@@ -159,11 +159,11 @@ def test_main_screen_signal_propagation(qapp, monkeypatch):
     # roll wiring
     seq = iter([4, 3])
     monkeypatch.setattr(random, "randint", lambda a, b: next(seq))
-    screen.dice_panel.dice[6].count = 1
+    screen.dice_panel.die_buttons[6].count = 1
     screen.dice_panel.mod_ctrl.setValue(0)
     screen.dice_panel.roll()
-    screen.dice_panel.dice[6].count = 0
-    screen.dice_panel.dice[4].count = 1
+    screen.dice_panel.die_buttons[6].count = 0
+    screen.dice_panel.die_buttons[4].count = 1
     screen.dice_panel.mod_ctrl.setValue(2)
     screen.dice_panel.roll()
     assert screen.roll_history.count() == 2


### PR DESCRIPTION
## Summary
- replace combo-based dice controls with a dice pad supporting multiple die types, modifiers, and roll/reset actions
- introduce DieButton with badge counts and update roll history parsing
- wire new roll workflow into main screen and style assets

## Testing
- `pytest --cov=better5e --cov-branch --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8cc19464832386777f05f9dd7f17