### PR TITLE
feat: smart autoscroll for roll history panel

### DIFF
--- a/better5e/UI/main_screen/components/roll_history.py
+++ b/better5e/UI/main_screen/components/roll_history.py
@@ -14,6 +14,7 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QWidget,
     QMenu,
+    QAbstractItemView,
 )
 
 from better5e.UI.style.theme import add_shadow
@@ -77,16 +78,26 @@ class RollCard(QWidget):
 
 
 class RollHistoryPanel(QListWidget):
-    """List widget showing past dice rolls."""
+    """A bottom-anchored feed of roll cards."""
 
-    def __init__(self) -> None:
-        super().__init__()
-        self.setSpacing(8)
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setVerticalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setSpacing(10)
         self.setAlternatingRowColors(False)
         self.setSelectionMode(QListWidget.SelectionMode.SingleSelection)
         self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.customContextMenuRequested.connect(self._show_context_menu)
         self.itemDoubleClicked.connect(self._reroll_item)
+
+        self._stick_bottom: bool = True
+        sb = self.verticalScrollBar()
+        sb.valueChanged.connect(self._on_scroll_value_changed)
+        sb.rangeChanged.connect(self._maybe_snap_to_bottom)
+        self.itemSelectionChanged.connect(
+            lambda: setattr(self, "_stick_bottom", self._is_at_bottom() and not self.selectedItems())
+        )
 
     def _parse_notation(self, notation: str) -> tuple[dict[int, int], int]:
         dice: dict[int, int] = {}
@@ -103,8 +114,19 @@ class RollHistoryPanel(QListWidget):
                 mod += int(part)
         return dice, mod
 
+    # ---------- public API ----------
+    def add_roll_card(self, card_widget: QWidget, data: dict | None = None) -> None:
+        """Append a roll card at the bottom."""
+        item = QListWidgetItem()
+        item.setSizeHint(card_widget.sizeHint())
+        if data is not None:
+            item.setData(Qt.ItemDataRole.UserRole, data)
+        self.addItem(item)
+        self.setItemWidget(item, card_widget)
+        # rangeChanged will fire -> _maybe_snap_to_bottom handles scroll
+
     def add_entry(self, text: str) -> None:
-        """Append a roll result to the list."""
+        """Parse a result string and append it to the list."""
         text = text.strip()
         if " = " not in text or "(" not in text or not text.endswith(")"):
             return
@@ -124,21 +146,21 @@ class RollHistoryPanel(QListWidget):
 
         add_shadow(card, blur=18, y=3)
 
-        item = QListWidgetItem()
-        item.setSizeHint(QSize(0, 72))
-        item.setData(Qt.ItemDataRole.UserRole, {
+        data = {
             "notation": notation_part,
             "total": total_i,
             "rolls": rolls,
             "mod": mod,
             "dice": dice_map,
-        })
-        self.addItem(item)
-        self.setItemWidget(item, card)
+        }
+        self.add_roll_card(card, data)
 
-    def clear_history(self) -> None:
-        """Remove all roll entries."""
+    def clearHistory(self) -> None:
+        """Remove all roll entries and reset scroll anchoring."""
         self.clear()
+        self._stick_bottom = True
+        # After first paint, stick to bottom
+        self._maybe_snap_to_bottom(0, self.verticalScrollBar().maximum())
 
     # context menu ---------------------------------------------------------
     def _show_context_menu(self, pos: QPoint) -> None:
@@ -155,7 +177,7 @@ class RollHistoryPanel(QListWidget):
             row = self.row(item)
             self.takeItem(row)
         elif action == clear_action:
-            self.clear_history()
+            self.clearHistory()
 
     def _copy_item(self, item: QListWidgetItem) -> None:
         data = item.data(Qt.ItemDataRole.UserRole)
@@ -173,3 +195,19 @@ class RollHistoryPanel(QListWidget):
         total = sum(rolls) + mod
         text = f"{data['notation']} = {total} ({', '.join(map(str, rolls))})"
         self.add_entry(text)
+
+    # ---------- autoscroll internals ----------
+    def _is_at_bottom(self) -> bool:
+        sb = self.verticalScrollBar()
+        return sb.value() >= sb.maximum() - 2
+
+    def _on_scroll_value_changed(self, _value: int) -> None:
+        self._stick_bottom = self._is_at_bottom()
+
+    def _maybe_snap_to_bottom(self, _minv: int, maxv: int) -> None:
+        if self._stick_bottom:
+            self.verticalScrollBar().setValue(maxv)
+
+    def showEvent(self, e) -> None:  # pragma: no cover - Qt event
+        super().showEvent(e)
+        self._maybe_snap_to_bottom(0, self.verticalScrollBar().maximum())

--- a/better5e/UI/main_screen/main_screen.py
+++ b/better5e/UI/main_screen/main_screen.py
@@ -1,4 +1,5 @@
 import random
+from datetime import datetime
 
 from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtWidgets import (
@@ -11,11 +12,12 @@ from PyQt6.QtWidgets import (
 from typing import TYPE_CHECKING
 
 from better5e.UI.core.basepage import BasePage
-from better5e.UI.main_screen.components.roll_history import RollHistoryPanel
+from better5e.UI.main_screen.components.roll_history import RollHistoryPanel, RollCard
 from better5e.UI.main_screen.components.dice_options import DiceOptionsPanel
 from better5e.UI.main_screen.components.section_header import SectionHeader
 from better5e.UI.main_screen.components.card_grid import CardGrid
 from better5e.UI.main_screen.components.homebrew_panel import HomebrewPanel
+from better5e.UI.style.theme import add_shadow
 
 if TYPE_CHECKING:  # pragma: no cover - imported only for type checking
     from better5e.UI.core.app import App
@@ -97,5 +99,16 @@ class MainScreen(BasePage):
         if modifier:
             sign = "+" if modifier > 0 else "-"
             notation = f"{notation} {sign} {abs(modifier)}" if notation else f"{modifier}"
-        text = f"{notation.strip()} = {total} ({', '.join(map(str, rolls))})"
-        self.roll_history.add_entry(text)
+        ts = datetime.now()
+        card = RollCard(notation.strip(), total, rolls, ts)
+        if dice.get(20) == 1 and len(rolls) == sum(dice.values()) and rolls and rolls[0] == 20:
+            card.setProperty("crit", True)
+        add_shadow(card, blur=18, y=3)
+        data = {
+            "notation": notation.strip(),
+            "total": total,
+            "rolls": rolls,
+            "mod": modifier,
+            "dice": dice,
+        }
+        self.roll_history.add_roll_card(card, data)

--- a/better5e/tests/test_ui_main_screen.py
+++ b/better5e/tests/test_ui_main_screen.py
@@ -62,8 +62,9 @@ def test_dice_roll_updates_history(qapp, monkeypatch):
     assert card.notation_label.text() == "2d4 + 1d6 + 3"
     assert card.total_label.text() == "11"
     assert [lab.text() for lab in card.roll_labels] == ["1", "2", "5"]
-    history.clear_history()
+    history.clearHistory()
     assert history.count() == 0
+    history._on_scroll_value_changed(0)
 
 
 def test_roll_history_context_and_reroll(qapp, monkeypatch):
@@ -167,6 +168,14 @@ def test_main_screen_signal_propagation(qapp, monkeypatch):
     screen.dice_panel.mod_ctrl.setValue(2)
     screen.dice_panel.roll()
     assert screen.roll_history.count() == 2
+
+    # explicit critical roll triggers crit property via _on_roll_requested
+    seq = iter([20])
+    monkeypatch.setattr(random, "randint", lambda a, b: next(seq))
+    screen._on_roll_requested({20: 1}, 0)
+    item = screen.roll_history.item(2)
+    card = screen.roll_history.itemWidget(item)
+    assert card.property("crit") is True
 
 
 def test_fmt_time_variants():


### PR DESCRIPTION
## Summary
- keep roll history anchored to bottom unless user scrolls up
- expose `add_roll_card` API and track roll data for context actions
- wire main screen to new roll history widget

## Testing
- `pytest --maxfail=1 --disable-warnings -q`
- `pytest --cov=better5e --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_689a93d1cf908323b47927a739052bbe