### PR TITLE
Refine layout and styling of main screen

### DIFF
--- a/better5e/UI/main_screen/components/dice_options.py
+++ b/better5e/UI/main_screen/components/dice_options.py
@@ -84,8 +84,17 @@ class DiceOptionsPanel(QWidget):
     rollRequested = pyqtSignal(dict, int)
     resetRequested = pyqtSignal()
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, *, compact: bool = True, parent: QWidget | None = None) -> None:
+        """Create the dice options panel.
+
+        Parameters
+        ----------
+        compact:
+            Whether to use tighter vertical spacing for controls.
+        parent:
+            Optional parent widget.
+        """
+        super().__init__(parent)
 
         root = QVBoxLayout(self)
         root.setContentsMargins(8, 8, 8, 8)
@@ -105,8 +114,8 @@ class DiceOptionsPanel(QWidget):
             grid.addWidget(btn, row, col)
             self.die_buttons[sides] = btn
 
-        self.mod_ctrl = ModifierControl()
-        root.addWidget(self.mod_ctrl)
+        self.modifierControl = ModifierControl()
+        root.addWidget(self.modifierControl)
 
         root.addItem(QSpacerItem(0, 0, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding))
 
@@ -120,7 +129,6 @@ class DiceOptionsPanel(QWidget):
 
         for b in (reset_btn, roll_btn):
             b.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-            b.setMinimumHeight(44)
 
         root.addWidget(reset_btn)
         root.addWidget(roll_btn)
@@ -131,18 +139,42 @@ class DiceOptionsPanel(QWidget):
         QShortcut(QKeySequence("R"), self, activated=self.roll)
         QShortcut(QKeySequence("Esc"), self, activated=self.reset)
 
-        self.roll_btn = roll_btn
-        self.reset_btn = reset_btn
+        self.rollBtn = roll_btn
+        self.resetBtn = reset_btn
+        # backward-compatible attribute names
+        self.roll_btn = self.rollBtn
+        self.reset_btn = self.resetBtn
+        self.mod_ctrl = self.modifierControl
+
+        # tighten vertical rhythm
+        root.setSpacing(8)
+        root.setContentsMargins(8, 6, 8, 8)
+
+        dense_h_btn = 38 if compact else 44
+        dense_h_edit = 38 if compact else 44
+
+        for btn in self.findChildren(
+            QPushButton, options=Qt.FindChildOption.FindChildrenRecursively
+        ):
+            if btn.property("class") == "die":
+                btn.setMinimumHeight(dense_h_btn)
+        self.resetBtn.setMinimumHeight(dense_h_btn)
+        self.rollBtn.setMinimumHeight(dense_h_btn + 6)
+
+        # modifier controls
+        self.modifierControl.edit.setMinimumHeight(dense_h_edit)
+        self.modifierControl.minus.setMinimumHeight(dense_h_edit)
+        self.modifierControl.plus.setMinimumHeight(dense_h_edit)
 
     # utilities ----------------------------------------------------------
     def _update_roll_enabled(self, *_: int) -> None:
         total = sum(btn.count for btn in self.die_buttons.values())
-        self.roll_btn.setEnabled(total > 0)
+        self.rollBtn.setEnabled(total > 0)
 
     def reset(self) -> None:
         for btn in self.die_buttons.values():
             btn.count = 0
-        self.mod_ctrl.setValue(0)
+        self.modifierControl.setValue(0)
         self._update_roll_enabled()
         self.resetRequested.emit()
 
@@ -150,11 +182,11 @@ class DiceOptionsPanel(QWidget):
         dice = {sides: btn.count for sides, btn in self.die_buttons.items() if btn.count}
         if not dice:
             return
-        self.rollRequested.emit(dice, self.mod_ctrl.value)
+        self.rollRequested.emit(dice, self.modifierControl.value)
 
     def state(self) -> Tuple[Dict[int, int], int]:
         dice = {sides: btn.count for sides, btn in self.die_buttons.items() if btn.count}
-        return dice, self.mod_ctrl.value
+        return dice, self.modifierControl.value
 
     def get_notation(self) -> str:
         dice, mod = self.state()

--- a/better5e/UI/main_screen/components/homebrew_panel.py
+++ b/better5e/UI/main_screen/components/homebrew_panel.py
@@ -1,5 +1,5 @@
 from PyQt6.QtCore import pyqtSignal
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QPushButton
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QPushButton, QLabel
 
 from better5e.UI.style.theme import add_shadow
 
@@ -12,7 +12,12 @@ class HomebrewPanel(QWidget):
     def __init__(self) -> None:
         super().__init__()
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(12)
+
+        title = QLabel("Homebrew")
+        title.setObjectName("SectionHeader")
+        layout.addWidget(title)
 
         kinds = [
             "feature",
@@ -31,4 +36,4 @@ class HomebrewPanel(QWidget):
             add_shadow(btn)
             layout.addWidget(btn)
 
-        layout.addStretch()
+        layout.addStretch(1)

--- a/better5e/UI/main_screen/main_screen.py
+++ b/better5e/UI/main_screen/main_screen.py
@@ -8,6 +8,8 @@ from PyQt6.QtWidgets import (
     QWidget,
     QScrollArea,
     QPushButton,
+    QSizePolicy,
+    QSpacerItem,
 )
 from typing import TYPE_CHECKING
 
@@ -32,58 +34,88 @@ class MainScreen(BasePage):
     createNewCampaign = pyqtSignal()
     openHomebrew = pyqtSignal(str)
 
-    def __init__(self, app: "App"):
+    def __init__(self, app: "App") -> None:
         super().__init__(app, "Home")
+
         body = self.layout()
+        body.setContentsMargins(0, 0, 0, 0)
 
-        columns = QHBoxLayout()
-        body.addLayout(columns)
+        # Root 3-column layout -------------------------------------------------
+        root = QHBoxLayout()
+        root.setContentsMargins(12, 8, 12, 12)
+        root.setSpacing(12)
+        body.addLayout(root)
 
-        # Left sidebar
-        left = QVBoxLayout()
+        # Left sidebar --------------------------------------------------------
+        leftPane = QWidget()
+        leftCol = QVBoxLayout(leftPane)
         self.roll_history = RollHistoryPanel()
-        left.addWidget(self.roll_history)
+        leftCol.addWidget(self.roll_history)
         self.dice_panel = DiceOptionsPanel()
         self.dice_panel.rollRequested.connect(self._on_roll_requested)
-        left.addWidget(self.dice_panel)
-        left.setStretch(0, 1)
-        columns.addLayout(left)
+        leftCol.addWidget(self.dice_panel)
+        leftCol.setStretch(0, 1)
 
-        # Center content
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        columns.addWidget(scroll, 1)
+        leftPane.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
+        leftPane.setMaximumWidth(520)
 
-        center_widget = QWidget()
-        scroll.setWidget(center_widget)
-        center_layout = QVBoxLayout(center_widget)
+        # Center content ------------------------------------------------------
+        centerPane = QScrollArea()
+        centerPane.setWidgetResizable(True)
+
+        centerWidget = QWidget()
+        centerPane.setWidget(centerWidget)
+        centerCol = QVBoxLayout(centerWidget)
+        centerCol.setContentsMargins(8, 0, 8, 0)
+        centerCol.setSpacing(12)
 
         # Characters section
+        charactersSection = QWidget()
+        charactersLayout = QVBoxLayout(charactersSection)
         self.characters_header = SectionHeader("My Characters")
         self.characters_header.seeAll.connect(self.seeAllCharacters.emit)
-        center_layout.addWidget(self.characters_header)
-        center_layout.addWidget(CardGrid(["Character 1", "Character 2", "Character 3"]))
+        charactersLayout.addWidget(self.characters_header)
+        charactersLayout.addWidget(CardGrid(["Character 1", "Character 2", "Character 3"]))
         self.characters_create = QPushButton("Create New")
         self.characters_create.setProperty("class", "primary")
         self.characters_create.clicked.connect(self.createNewCharacter.emit)
-        center_layout.addWidget(self.characters_create)
+        charactersLayout.addWidget(self.characters_create)
 
         # Campaigns section
+        campaignsSection = QWidget()
+        campaignsLayout = QVBoxLayout(campaignsSection)
         self.campaigns_header = SectionHeader("My Campaigns")
         self.campaigns_header.seeAll.connect(self.seeAllCampaigns.emit)
-        center_layout.addWidget(self.campaigns_header)
-        center_layout.addWidget(CardGrid(["Campaign 1", "Campaign 2", "Campaign 3"]))
+        campaignsLayout.addWidget(self.campaigns_header)
+        campaignsLayout.addWidget(CardGrid(["Campaign 1", "Campaign 2", "Campaign 3"]))
         self.campaigns_create = QPushButton("Create New")
         self.campaigns_create.setProperty("class", "primary")
         self.campaigns_create.clicked.connect(self.createNewCampaign.emit)
-        center_layout.addWidget(self.campaigns_create)
+        campaignsLayout.addWidget(self.campaigns_create)
 
-        center_layout.addStretch()
+        centerCol.addWidget(charactersSection)
+        centerCol.addItem(
+            QSpacerItem(0, 0, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+        )
+        centerCol.addWidget(campaignsSection)
 
-        # Right sidebar
-        self.homebrew_panel = HomebrewPanel()
-        self.homebrew_panel.openHomebrew.connect(self.openHomebrew.emit)
-        columns.addWidget(self.homebrew_panel)
+        # Right sidebar -------------------------------------------------------
+        rightPane = HomebrewPanel()
+        rightPane.openHomebrew.connect(self.openHomebrew.emit)
+        rightPane.setMinimumWidth(260)
+        rightPane.setMaximumWidth(320)
+        rightPane.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+
+        # Assemble layout -----------------------------------------------------
+        root.addWidget(leftPane)
+        root.addWidget(centerPane)
+        root.addWidget(rightPane)
+
+        root.setStretch(0, 3)
+        root.setStretch(1, 7)
+        root.setStretch(2, 3)
+
+        self.homebrew_panel = rightPane
 
     # roll handling -----------------------------------------------------
     def _on_roll_requested(self, dice: dict[int, int], modifier: int) -> None:

--- a/better5e/UI/main_screen/main_screen.py
+++ b/better5e/UI/main_screen/main_screen.py
@@ -111,9 +111,10 @@ class MainScreen(BasePage):
         root.addWidget(centerPane)
         root.addWidget(rightPane)
 
-        root.setStretch(0, 3)
-        root.setStretch(1, 7)
-        root.setStretch(2, 3)
+        # Middle column takes half the width (25/50/25 distribution)
+        root.setStretch(0, 1)
+        root.setStretch(1, 2)
+        root.setStretch(2, 1)
 
         self.homebrew_panel = rightPane
 

--- a/better5e/UI/main_screen/main_screen.py
+++ b/better5e/UI/main_screen/main_screen.py
@@ -57,7 +57,7 @@ class MainScreen(BasePage):
         leftCol.setStretch(0, 1)
 
         leftPane.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
-        leftPane.setMaximumWidth(520)
+        leftPane.setMaximumWidth(400)
 
         # Center content ------------------------------------------------------
         centerPane = QScrollArea()
@@ -111,10 +111,10 @@ class MainScreen(BasePage):
         root.addWidget(centerPane)
         root.addWidget(rightPane)
 
-        # Middle column takes half the width (25/50/25 distribution)
-        root.setStretch(0, 1)
-        root.setStretch(1, 2)
-        root.setStretch(2, 1)
+        # Keep sidebars compact while center expands
+        root.setStretch(0, 0)
+        root.setStretch(1, 1)
+        root.setStretch(2, 0)
 
         self.homebrew_panel = rightPane
 

--- a/better5e/UI/style/theme.qss
+++ b/better5e/UI/style/theme.qss
@@ -127,6 +127,13 @@ QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
     qproperty-flat: true;
 }
 
+QLabel#SectionHeader {
+  font-size: 18px;
+  font-weight: 700;
+  color: $text;
+  margin-bottom: 4px;
+}
+
 /* QGroupBox styling */
 QGroupBox {
     border: 1px solid $border;
@@ -182,7 +189,7 @@ QLabel[class~="chip"] {
 
 /* Dice buttons */
 QPushButton[class~="die"] {
-  min-width: 72px; min-height: 44px;
+  min-width: 72px; min-height: 38px;
   padding: 8px 14px;
   border-radius: 12px;
   background: $surfaceAlt;
@@ -215,5 +222,5 @@ QWidget#ModifierControl QToolButton {
 QWidget#ModifierControl QToolButton:hover { border-color: $accent; }
 
 /* Actions */
-QPushButton#ResetBtn { margin-top: 8px; }
-QPushButton#RollBtn  { margin-top: 6px; }
+QPushButton#ResetBtn { margin-top: 8px; min-height: 38px; }
+QPushButton#RollBtn  { margin-top: 6px; min-height: 44px; }

--- a/better5e/tests/test_ui_main_screen.py
+++ b/better5e/tests/test_ui_main_screen.py
@@ -132,7 +132,7 @@ def test_homebrew_panel_signals(qapp):
     received = []
     panel.openHomebrew.connect(received.append)
     # trigger first button
-    btn = panel.layout().itemAt(0).widget()
+    btn = panel.layout().itemAt(1).widget()
     btn.click()
     assert received == ["feature"]
 
@@ -152,7 +152,7 @@ def test_main_screen_signal_propagation(qapp, monkeypatch):
     screen.characters_create.click()
     screen.campaigns_header.button.click()
     screen.campaigns_create.click()
-    hb_btn = screen.homebrew_panel.layout().itemAt(1).widget()
+    hb_btn = screen.homebrew_panel.layout().itemAt(2).widget()
     hb_btn.click()
 
     assert signals == ["see_chars", "new_char", "see_camps", "new_camp", "class"]


### PR DESCRIPTION
## Summary
- Constrain main screen columns and anchor campaigns section
- Add compact dice pad with denser control heights
- Introduce titled Homebrew panel and section header styling

## Testing
- `pytest --cov=better5e --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_689a9743c9b48323b93def8e0ab3e871