### PR TITLE
Align title bar gutter and enlarge app title

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Main screen sections use the `Section` widget; dividers are removed and styling lives in the theme.
 - Page gutters are unified via `UI.style.tokens.gutter()` and used by the title bar and main screen layout.
 - The title bar's left margin is defined by `GUTTER` in `UI/shell/chrome.py`; keep this value in sync with `MainScreen` layout margins so the app title aligns with the dice panel.
+- The app title uses an 8px text indent and a 2px top margin so its left edge and baseline line up precisely with the dice options panel below.
 - Main screen center uses a borderless scroll area named `CenterScroll` with `LeftPane`, `CenterPane`, and `RightPane` named for styling.
 - Style `CenterScroll` by targeting its `qt_scrollarea_viewport` so child widgets like the "Create New" buttons keep their own borders and backgrounds.
 - DiceOptionsPanel centers its dice grid and modifier control; dice buttons are fixed at 60px wide with 8px gutters. ModifierControl uses wide ± buttons and a ~40px number field to keep controls compact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Coverage artifacts (e.g. `.coverage`) are ignored and should not be committed.
 - Main screen sections use the `Section` widget; dividers are removed and styling lives in the theme.
 - Page gutters are unified via `UI.style.tokens.gutter()` and used by the title bar and main screen layout.
+- The title bar's left margin is defined by `GUTTER` in `UI/shell/chrome.py`; keep this value in sync with `MainScreen` layout margins so the app title aligns with the dice panel.
 - Main screen center uses a borderless scroll area named `CenterScroll` with `LeftPane`, `CenterPane`, and `RightPane` named for styling.
 - Style `CenterScroll` by targeting its `qt_scrollarea_viewport` so child widgets like the "Create New" buttons keep their own borders and backgrounds.
 - DiceOptionsPanel centers its dice grid and modifier control; dice buttons are fixed at 60px wide with 8px gutters. ModifierControl uses wide ± buttons and a ~40px number field to keep controls compact.

--- a/better5e/UI/shell/chrome.py
+++ b/better5e/UI/shell/chrome.py
@@ -17,7 +17,10 @@ from better5e.UI.style.tokens import gutter
 # Keep the title bar aligned with main screen gutters.  This value should
 # mirror the horizontal margins used in ``main_screen.py`` so the title text
 # lines up exactly with the app content (e.g. the dice box).
+# Outer gutter matches the main screen margins.  The title text is indented
+# slightly further to align with the dice panel content below.
 GUTTER = gutter() if callable(gutter) else 20
+TITLE_INDENT = 8
 
 
 class TitleBar(QFrame):
@@ -37,6 +40,8 @@ class TitleBar(QFrame):
         self.title = QLabel(title, self)
         self.title.setObjectName("AppTitle")
         self.title.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        self.title.setIndent(TITLE_INDENT)
+        self.title.setContentsMargins(0, 2, 0, 0)
         f = self.title.font()
         f.setPixelSize(20)
         f.setWeight(700)

--- a/better5e/UI/shell/chrome.py
+++ b/better5e/UI/shell/chrome.py
@@ -14,6 +14,12 @@ from PyQt6.QtWidgets import (
 from better5e.UI.style.tokens import gutter
 
 
+# Keep the title bar aligned with main screen gutters.  This value should
+# mirror the horizontal margins used in ``main_screen.py`` so the title text
+# lines up exactly with the app content (e.g. the dice box).
+GUTTER = gutter() if callable(gutter) else 20
+
+
 class TitleBar(QFrame):
     """Custom title bar with app title on left and window controls on right."""
     HEIGHT = 40
@@ -24,16 +30,15 @@ class TitleBar(QFrame):
         self.setFixedHeight(self.HEIGHT)
         self._mouse_pos: QPoint | None = None
 
-        G = gutter() if callable(gutter) else 20
         row = QHBoxLayout(self)
-        row.setContentsMargins(G, 0, G, 0)
+        row.setContentsMargins(GUTTER, 0, GUTTER, 0)
         row.setSpacing(8)
 
         self.title = QLabel(title, self)
         self.title.setObjectName("AppTitle")
         self.title.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
         f = self.title.font()
-        f.setPixelSize(18)
+        f.setPixelSize(20)
         f.setWeight(700)
         self.title.setFont(f)
 

--- a/better5e/UI/style/theme.qss
+++ b/better5e/UI/style/theme.qss
@@ -12,7 +12,7 @@ QFrame#TitleBar { background: $bg; border-bottom: none; }
 QWidget#WindowContent, QMainWindow#FramelessMainWindow { background: $bg; border: none; }
 QLabel#AppTitle {
   color: $text;
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 700;
   letter-spacing: .02em;
   padding-left: 0;

--- a/better5e/tests/test_chrome.py
+++ b/better5e/tests/test_chrome.py
@@ -35,6 +35,8 @@ def test_chrome_basic_interactions(qapp, monkeypatch):
     assert tb.btnMin.font().pixelSize() == 16
     assert tb.title.font().pixelSize() == 20
     assert tb.layout().contentsMargins().left() == gutter()
+    assert tb.title.contentsMargins().top() == 2
+    assert tb.title.indent() == 8
 
     tb.btnMin.click()
     tb.btnMax.click()

--- a/better5e/tests/test_chrome.py
+++ b/better5e/tests/test_chrome.py
@@ -33,7 +33,7 @@ def test_chrome_basic_interactions(qapp, monkeypatch):
     tb = win.titleBar
     assert tb.btnMin.size().width() == 42 and tb.btnMin.size().height() == 32
     assert tb.btnMin.font().pixelSize() == 16
-    assert tb.title.font().pixelSize() == 18
+    assert tb.title.font().pixelSize() == 20
     assert tb.layout().contentsMargins().left() == gutter()
 
     tb.btnMin.click()


### PR DESCRIPTION
## Summary
- Align title bar using shared `GUTTER` value so app title lines up with main content
- Increase app title font to 20px and update QSS styling
- Adjust tests for new title size

## Testing
- `pytest --maxfail=1 --disable-warnings -q --cov=better5e`


------
https://chatgpt.com/codex/tasks/task_e_689ab30b50b4832387d8800806c65d22