### PR TITLE
feat: restyle dice pad layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,5 +8,5 @@
 - Page gutters are unified via `UI.style.tokens.gutter()` and used by the title bar and main screen layout.
 - Main screen center uses a borderless scroll area named `CenterScroll` with `LeftPane`, `CenterPane`, and `RightPane` named for styling.
 - Style `CenterScroll` by targeting its `qt_scrollarea_viewport` so child widgets like the "Create New" buttons keep their own borders and backgrounds.
-- DiceOptionsPanel centers its dice grid and modifier control; dice buttons are fixed at 60px wide with 8px gutters. ModifierControl uses wide ± buttons and a ~40px number field to keep controls compact.
+- DiceOptionsPanel uses a 4×2 grid of dice buttons sized 88×44 with 10 px gutters. Modifier controls are centered with 40×40 ± buttons flanking a ~72 px number field.
 

--- a/better5e/UI/main_screen/components/dice_options.py
+++ b/better5e/UI/main_screen/components/dice_options.py
@@ -6,14 +6,13 @@ from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtGui import QIntValidator, QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QWidget,
-    QGridLayout,
     QVBoxLayout,
+    QGridLayout,
     QHBoxLayout,
     QPushButton,
     QToolButton,
     QLineEdit,
     QSizePolicy,
-    QSpacerItem,
 )
 
 from better5e.UI.main_screen.components.die_button import DieButton
@@ -32,36 +31,27 @@ class ModifierControl(QWidget):
         self.setObjectName("ModifierControl")
         self._val = 0
 
-        minus = QToolButton()
-        minus.setText("-")
+        minus = QToolButton(text="–")
+        minus.setObjectName("ModBtn")
+        minus.setFixedSize(40, 40)
 
-        minus.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        plus = QToolButton()
-        plus.setText("+")
-        plus.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-
-        minus.setMinimumWidth(36)
-        plus = QToolButton()
-        plus.setText("+")
-        plus.setMinimumWidth(36)
+        plus = QToolButton(text="+")
+        plus.setObjectName("ModBtn")
+        plus.setFixedSize(40, 40)
 
         edit = QLineEdit("0")
+        edit.setObjectName("ModEdit")
         edit.setValidator(QIntValidator(-999, 999, self))
         edit.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        edit.setFixedWidth(40)
+        edit.setFixedWidth(72)
+        edit.setMinimumHeight(40)
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(8)
+        layout.setSpacing(10)
         layout.addWidget(minus)
         layout.addWidget(edit)
         layout.addWidget(plus)
-        layout.setStretch(0, 1)
-        layout.setStretch(2, 1)
-
-        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-
-        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
         minus.clicked.connect(lambda: self.setValue(self._val - 1))
         plus.clicked.connect(lambda: self.setValue(self._val + 1))
@@ -100,98 +90,77 @@ class DiceOptionsPanel(QWidget):
     rollRequested = pyqtSignal(dict, int)
     resetRequested = pyqtSignal()
 
-    def __init__(self, *, compact: bool = True, parent: QWidget | None = None) -> None:
-        """Create the dice options panel.
-
-        Parameters
-        ----------
-        compact:
-            Whether to use tighter vertical spacing for controls.
-        parent:
-            Optional parent widget.
-        """
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
         root = QVBoxLayout(self)
-        root.setContentsMargins(8, 8, 8, 8)
+        root.setContentsMargins(12, 10, 12, 12)
         root.setSpacing(12)
 
+        # --- Dice grid ---------------------------------------------------
         grid = QGridLayout()
         grid.setContentsMargins(0, 0, 0, 0)
-
-        grid.setSpacing(8)
-        grid.setHorizontalSpacing(8)
-        grid.setVerticalSpacing(8)
-        root.addLayout(grid)
-        root.setAlignment(grid, Qt.AlignmentFlag.AlignHCenter)
-
+        grid.setHorizontalSpacing(10)
+        grid.setVerticalSpacing(10)
         self.die_buttons: dict[int, DieButton] = {}
+
         for i, sides in enumerate(DICE_SIDES):
-            btn = DieButton(sides)
-            btn.setToolTip("Coin flip (d2)" if sides == 2 else f"d{sides}")
-            btn.setFixedWidth(60)
-            btn.countChanged.connect(self._update_roll_enabled)
             row, col = divmod(i, 4)
+            btn = DieButton(sides)
+            btn.setObjectName("DieBtn")
+            btn.setMinimumSize(88, 44)
+            btn.setMaximumHeight(44)
+            btn.setSizePolicy(
+                QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+            )
+            btn.countChanged.connect(self._update_roll_enabled)
             grid.addWidget(btn, row, col)
             self.die_buttons[sides] = btn
 
+        for c in range(4):
+            grid.setColumnStretch(c, 1)
+
+        root.addLayout(grid)
+
+        # --- Modifier row (compact, centered) ---------------------------
+        modWrap = QHBoxLayout()
+        modWrap.setContentsMargins(0, 0, 0, 0)
+        modWrap.setSpacing(10)
+        modWrap.addStretch(1)
+
         self.modifierControl = ModifierControl()
+        modWrap.addWidget(self.modifierControl)
+        modWrap.addStretch(1)
 
-        self.modifierControl.setFixedWidth(60 * 4 + 8 * 3)
+        root.addLayout(modWrap)
 
+        # --- Actions (full width) --------------------------------------
+        self.resetBtn = QPushButton("Reset")
+        self.resetBtn.setObjectName("ResetBtn")
+        self.rollBtn = QPushButton("Roll")
+        self.rollBtn.setObjectName("RollBtn")
 
-        root.addWidget(self.modifierControl, alignment=Qt.AlignmentFlag.AlignHCenter)
+        for b in (self.resetBtn, self.rollBtn):
+            b.setMinimumHeight(46)
+            b.setSizePolicy(
+                QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+            )
+            root.addWidget(b)
 
-        root.addItem(QSpacerItem(0, 0, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding))
-
-        reset_btn = QPushButton("Reset")
-        reset_btn.setObjectName("ResetBtn")
-        reset_btn.setProperty("class", "secondary")
-        roll_btn = QPushButton("Roll")
-        roll_btn.setObjectName("RollBtn")
-        roll_btn.setProperty("class", "primary")
-        roll_btn.setEnabled(False)
-
-        for b in (reset_btn, roll_btn):
-            b.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-
-        root.addWidget(reset_btn)
-        root.addWidget(roll_btn)
-
-        reset_btn.clicked.connect(self.reset)
-        roll_btn.clicked.connect(self.roll)
-
+        # signals -------------------------------------------------------
+        self.resetBtn.clicked.connect(self.reset)
+        self.rollBtn.clicked.connect(self.roll)
         QShortcut(QKeySequence("R"), self, activated=self.roll)
         QShortcut(QKeySequence("Esc"), self, activated=self.reset)
 
-        self.rollBtn = roll_btn
-        self.resetBtn = reset_btn
+        self.rollBtn.setEnabled(False)
+
         # backward-compatible attribute names
         self.roll_btn = self.rollBtn
         self.reset_btn = self.resetBtn
         self.mod_ctrl = self.modifierControl
 
-        # tighten vertical rhythm
-        root.setSpacing(8)
-        root.setContentsMargins(8, 6, 8, 8)
-
-        dense_h_btn = 38 if compact else 44
-        dense_h_edit = 38 if compact else 44
-
-        for btn in self.findChildren(
-            QPushButton, options=Qt.FindChildOption.FindChildrenRecursively
-        ):
-            if btn.property("class") == "die":
-                btn.setMinimumHeight(dense_h_btn)
-        self.resetBtn.setMinimumHeight(dense_h_btn)
-        self.rollBtn.setMinimumHeight(dense_h_btn + 6)
-
-        # modifier controls
-        self.modifierControl.edit.setMinimumHeight(dense_h_edit)
-        self.modifierControl.minus.setMinimumHeight(dense_h_edit)
-        self.modifierControl.plus.setMinimumHeight(dense_h_edit)
-
-    # utilities ----------------------------------------------------------
+    # utilities ---------------------------------------------------------
     def _update_roll_enabled(self, *_: int) -> None:
         total = sum(btn.count for btn in self.die_buttons.values())
         self.rollBtn.setEnabled(total > 0)
@@ -204,20 +173,21 @@ class DiceOptionsPanel(QWidget):
         self.resetRequested.emit()
 
     def roll(self) -> None:
-        dice = {sides: btn.count for sides, btn in self.die_buttons.items() if btn.count}
+        dice = {s: b.count for s, b in self.die_buttons.items() if b.count}
         if not dice:
             return
         self.rollRequested.emit(dice, self.modifierControl.value)
 
     def state(self) -> Tuple[Dict[int, int], int]:
-        dice = {sides: btn.count for sides, btn in self.die_buttons.items() if btn.count}
+        dice = {s: b.count for s, b in self.die_buttons.items() if b.count}
         return dice, self.modifierControl.value
 
     def get_notation(self) -> str:
         dice, mod = self.state()
-        parts = [f"{cnt}d{sides}" for sides, cnt in dice.items()]
+        parts = [f"{cnt}d{s}" for s, cnt in dice.items()]
         notation = " + ".join(parts)
         if mod:
             sign = "+" if mod > 0 else "-"
             notation = f"{notation} {sign} {abs(mod)}" if notation else f"{mod}"
         return notation.strip()
+

--- a/better5e/UI/style/theme.qss
+++ b/better5e/UI/style/theme.qss
@@ -215,18 +215,16 @@ QLabel[class~="chip"] {
 }
 
 /* Dice buttons */
-QPushButton[class~="die"] {
-  min-width: 72px; min-height: 38px;
-  padding: 8px 14px;
-  border-radius: 12px;
+QPushButton#DieBtn {
   background: $surfaceAlt;
   border: 1px solid $border;
+  border-radius: 12px;
   font-weight: 600;
 }
-QPushButton[class~="die"]:hover { border-color: $accent; }
-QPushButton[class~="die"]:pressed { transform: translateY(1px); }
+QPushButton#DieBtn:hover { border-color: $accent; }
+QPushButton#DieBtn:pressed { transform: translateY(1px); }
 
-QPushButton[class~="die"] QLabel#DieBadge {
+QPushButton#DieBtn QLabel#DieBadge {
   background: $accent;
   color: white;
   border-radius: 9px;
@@ -236,20 +234,38 @@ QPushButton[class~="die"] QLabel#DieBadge {
   font-weight: 700;
 }
 
-/* Modifier control */
-QWidget#ModifierControl { background: transparent; }
-QWidget#ModifierControl QLineEdit {
-  min-height: 36px; font-size: 14px; text-align: center;
-  border-radius: 10px; border: 1px solid $border; background: $surfaceAlt; color: $text;
+/* Modifier controls */
+QToolButton#ModBtn {
+  background: $surfaceAlt;
+  border: 1px solid $border;
+  border-radius: 10px;
+  font-size: 18px;
+  font-weight: 700;
 }
-QWidget#ModifierControl QToolButton {
-  min-width: 36px; min-height: 36px;
-  border-radius: 10px; border: 1px solid $border; background: $surfaceAlt; color: $text;
-}
-QWidget#ModifierControl QToolButton:hover { border-color: $accent; }
+QToolButton#ModBtn:hover { border-color: $accent; }
 
-/* Actions */
-QPushButton#ResetBtn { margin-top: 8px; min-height: 38px; }
-QPushButton#RollBtn  { margin-top: 6px; min-height: 44px; }
-QPushButton#RollBtn:hover { background-color: $accentHover; }
-QPushButton#RollBtn:pressed { background-color: $accentHover; }
+QLineEdit#ModEdit {
+  background: $surfaceAlt;
+  border: 1px solid $border;
+  border-radius: 12px;
+  color: $text;
+  font-size: 16px;
+}
+
+/* Actions — ensure hover remains visible */
+QPushButton#ResetBtn {
+  border: 1px solid $border;
+  background: $surfaceAlt;
+  border-radius: 12px;
+}
+QPushButton#ResetBtn:hover { border-color: $accent; }
+
+QPushButton#RollBtn {
+  background: $accent;
+  color: white;
+  border: none;
+  border-radius: 14px;
+  font-weight: 700;
+}
+QPushButton#RollBtn:hover { background: $accentHover; }
+QPushButton#RollBtn:disabled { opacity: .55; }


### PR DESCRIPTION
## Summary
- Rebuild DiceOptionsPanel with a uniform 4x2 grid and centered modifier controls
- Refresh theme styles for dice buttons, modifier controls, and action buttons
- Document new dice pad sizing guidelines in AGENTS instructions

## Testing
- `pytest --maxfail=1 --disable-warnings -q --cov=better5e`

------
https://chatgpt.com/codex/tasks/task_e_689ab46e5b408323b5e36e0acfcfc0c6