### PR TITLE
Align Homebrew header styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,4 +11,5 @@
 - Main screen center uses a borderless scroll area named `CenterScroll` with `LeftPane`, `CenterPane`, and `RightPane` named for styling.
 - Style `CenterScroll` by targeting its `qt_scrollarea_viewport` so child widgets like the "Create New" buttons keep their own borders and backgrounds.
 - DiceOptionsPanel uses a 4×2 grid of dice buttons sized 88×44 with 10 px gutters. Modifier controls are centered with 40×40 ± buttons flanking a ~72 px number field.
+- HomebrewPanel titles should use `SectionHeader` with its 'See All' button hidden for consistent styling.
 

--- a/better5e/UI/main_screen/components/homebrew_panel.py
+++ b/better5e/UI/main_screen/components/homebrew_panel.py
@@ -1,6 +1,7 @@
 from PyQt6.QtCore import pyqtSignal
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QPushButton, QLabel
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QPushButton
 
+from better5e.UI.main_screen.components.section_header import SectionHeader
 from better5e.UI.style.theme import add_shadow
 
 
@@ -15,9 +16,9 @@ class HomebrewPanel(QWidget):
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(12)
 
-        title = QLabel("Homebrew")
-        title.setObjectName("SectionHeader")
-        layout.addWidget(title)
+        header = SectionHeader("Homebrew")
+        header.button.hide()
+        layout.addWidget(header)
 
         kinds = [
             "feature",


### PR DESCRIPTION
## Summary
- Style Homebrew sidebar header with shared SectionHeader component and hide the unused See All button for a consistent look
- Document use of SectionHeader in AGENTS instructions

## Testing
- `pytest --maxfail=1 --disable-warnings -q --cov=better5e`

------
https://chatgpt.com/codex/tasks/task_e_689ab72f64488323895d99b90812399b