### PR TITLE
Enhance title bar action buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,5 @@
 - DiceOptionsPanel uses a 4×2 grid of dice buttons sized 88×44 with 10 px gutters. Modifier controls are centered with 40×40 ± buttons flanking a ~72 px number field.
 - HomebrewPanel titles should use `SectionHeader` with its 'See All' button hidden for consistent styling.
 
+- Title bar action buttons (`WinBtnMin`, `WinBtnMax`, `WinBtnClose`) use a fixed size of 52×40 with ~2 px bottom padding to center the glyphs. Keep these dimensions in sync with `TitleBar.HEIGHT` so the buttons align with the app title.
+

--- a/better5e/UI/shell/chrome.py
+++ b/better5e/UI/shell/chrome.py
@@ -61,7 +61,7 @@ class TitleBar(QFrame):
             b.setCursor(Qt.CursorShape.PointingHandCursor)
             b.setProperty("class", "winbtn")
             b.setToolTip(tip)
-            b.setFixedSize(42, 32)
+            b.setFixedSize(52, 40)
             f = b.font()
             f.setPixelSize(16)
             f.setWeight(600)

--- a/better5e/UI/style/theme.qss
+++ b/better5e/UI/style/theme.qss
@@ -27,7 +27,7 @@ QPushButton[class~="winbtn"] {
   color: $text;
   font-size: 16px;
   font-weight: 600;
-  padding-bottom: 0px;
+  padding-bottom: 2px;
 }
 QPushButton[class~="winbtn"]:hover { background: rgba(255,255,255,0.06); }
 QPushButton#WinBtnClose:hover { background: rgba(244, 63, 94, 0.25); }  /* soft red */

--- a/better5e/tests/test_chrome.py
+++ b/better5e/tests/test_chrome.py
@@ -31,7 +31,7 @@ def test_chrome_basic_interactions(qapp, monkeypatch):
     win.set_content(new_content)
 
     tb = win.titleBar
-    assert tb.btnMin.size().width() == 42 and tb.btnMin.size().height() == 32
+    assert tb.btnMin.size().width() == 52 and tb.btnMin.size().height() == 40
     assert tb.btnMin.font().pixelSize() == 16
     assert tb.title.font().pixelSize() == 24
     assert tb.layout().contentsMargins().left() == gutter()


### PR DESCRIPTION
## Summary
- Enlarge title bar window control buttons for better balance
- Shift window control glyphs upward for visual centering
- Document title bar button sizing in AGENTS instructions

## Testing
- `pytest --maxfail=1 --disable-warnings -q --cov=better5e`

------
https://chatgpt.com/codex/tasks/task_e_689abc088fb8832389bf359e0fbf7197