### PR TITLE
Add feature builder and creation view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,4 +5,5 @@ Please follow these guidelines when working in this repository:
 - Use four spaces for Python indentation.
 - Before committing, run `python manage.py test` to ensure tests pass.
 - Update documentation when setup steps change.
+- Store optional feature properties (prerequisites, charges, grants, etc.) in the `Feat.data` JSON field; only `name` and `description` are required.
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from django import forms
+
+from .models import Feat, Class, Species
+
+
+class FeatForm(forms.ModelForm):
+    prerequisite_class = forms.ModelChoiceField(
+        queryset=Class.objects.all(),
+        required=False,
+        widget=forms.Select(attrs={"class": "select select-bordered w-full"}),
+    )
+    prerequisite_class_level = forms.IntegerField(
+        min_value=1,
+        required=False,
+        widget=forms.NumberInput(attrs={"class": "input input-bordered w-full"}),
+    )
+    prerequisite_feature = forms.ModelChoiceField(
+        queryset=Feat.objects.all(),
+        required=False,
+        widget=forms.Select(attrs={"class": "select select-bordered w-full"}),
+    )
+    prerequisite_total_level = forms.IntegerField(
+        min_value=1,
+        required=False,
+        widget=forms.NumberInput(attrs={"class": "input input-bordered w-full"}),
+    )
+    prerequisite_species = forms.ModelChoiceField(
+        queryset=Species.objects.all(),
+        required=False,
+        widget=forms.Select(attrs={"class": "select select-bordered w-full"}),
+    )
+    charges = forms.IntegerField(
+        min_value=0,
+        required=False,
+        widget=forms.NumberInput(attrs={"class": "input input-bordered w-full"}),
+    )
+    recharge_type = forms.CharField(
+        max_length=64,
+        required=False,
+        widget=forms.TextInput(attrs={"class": "input input-bordered w-full"}),
+    )
+    grants = forms.CharField(required=False, widget=forms.HiddenInput())
+
+    class Meta:
+        model = Feat
+        fields = ["name", "description"]
+        widgets = {
+            "name": forms.TextInput(attrs={"class": "input input-bordered w-full"}),
+            "description": forms.Textarea(
+                attrs={"class": "textarea textarea-bordered w-full", "rows": 4}
+            ),
+        }
+
+    def save(self, commit: bool = True) -> Feat:
+        feat = super().save(commit=False)
+        data: dict = {}
+        cd = self.cleaned_data
+        prereq = {}
+        if cd.get("prerequisite_class") and cd.get("prerequisite_class_level"):
+            prereq["class"] = cd["prerequisite_class"].id
+            prereq["class_level"] = cd["prerequisite_class_level"]
+        if cd.get("prerequisite_feature"):
+            prereq["feature"] = cd["prerequisite_feature"].id
+        if cd.get("prerequisite_total_level"):
+            prereq["total_level"] = cd["prerequisite_total_level"]
+        if cd.get("prerequisite_species"):
+            prereq["species"] = cd["prerequisite_species"].id
+        if prereq:
+            data["prerequisites"] = prereq
+        if cd.get("charges") is not None:
+            data["charges"] = cd["charges"]
+        if cd.get("recharge_type"):
+            data["recharge_type"] = cd["recharge_type"]
+        import json
+
+        if cd.get("grants"):
+            try:
+                data["grants"] = json.loads(cd["grants"])
+            except Exception:
+                pass
+        feat.data = data
+        if commit:
+            feat.save()
+        return feat

--- a/core/forms.py
+++ b/core/forms.py
@@ -42,6 +42,7 @@ class FeatForm(forms.ModelForm):
         widget=forms.TextInput(attrs={"class": "input input-bordered w-full"}),
     )
     grants = forms.CharField(required=False, widget=forms.HiddenInput())
+    modifiers = forms.CharField(required=False, widget=forms.HiddenInput())
 
     class Meta:
         model = Feat
@@ -78,6 +79,14 @@ class FeatForm(forms.ModelForm):
         if cd.get("grants"):
             try:
                 data["grants"] = json.loads(cd["grants"])
+            except Exception:
+                pass
+        if cd.get("modifiers"):
+            try:
+                mods = json.loads(cd["modifiers"]) or []
+                # Expect list of {target, operation, value}
+                if isinstance(mods, list):
+                    data["modifiers"] = mods
             except Exception:
                 pass
         feat.data = data

--- a/core/templates/feat_form.html
+++ b/core/templates/feat_form.html
@@ -13,47 +13,86 @@
         {{ form.description }}
     </div>
     <fieldset class="border p-4 rounded-lg">
-        <legend class="font-semibold">Prerequisites (optional)</legend>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <legend class="font-semibold">Optional Properties</legend>
+        <div class="space-y-6">
             <div>
-                <label for="{{ form.prerequisite_class.id_for_label }}" class="block mb-1">Class</label>
-                {{ form.prerequisite_class }}
+                <h3 class="font-semibold mb-2">Prerequisites</h3>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label for="{{ form.prerequisite_class.id_for_label }}" class="block mb-1">Class</label>
+                        {{ form.prerequisite_class }}
+                    </div>
+                    <div>
+                        <label for="{{ form.prerequisite_class_level.id_for_label }}" class="block mb-1">Class Level</label>
+                        {{ form.prerequisite_class_level }}
+                    </div>
+                    <div>
+                        <label for="{{ form.prerequisite_feature.id_for_label }}" class="block mb-1">Feature</label>
+                        {{ form.prerequisite_feature }}
+                    </div>
+                    <div>
+                        <label for="{{ form.prerequisite_total_level.id_for_label }}" class="block mb-1">Total Level</label>
+                        {{ form.prerequisite_total_level }}
+                    </div>
+                    <div>
+                        <label for="{{ form.prerequisite_species.id_for_label }}" class="block mb-1">Species</label>
+                        {{ form.prerequisite_species }}
+                    </div>
+                </div>
             </div>
             <div>
-                <label for="{{ form.prerequisite_class_level.id_for_label }}" class="block mb-1">Class Level</label>
-                {{ form.prerequisite_class_level }}
+                <h3 class="font-semibold mb-2">Usage</h3>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label for="{{ form.charges.id_for_label }}" class="block mb-1">Charges</label>
+                        {{ form.charges }}
+                    </div>
+                    <div>
+                        <label for="{{ form.recharge_type.id_for_label }}" class="block mb-1">Recharge Type</label>
+                        {{ form.recharge_type }}
+                    </div>
+                </div>
             </div>
             <div>
-                <label for="{{ form.prerequisite_feature.id_for_label }}" class="block mb-1">Feature</label>
-                {{ form.prerequisite_feature }}
+                <h3 class="font-semibold mb-2">Grants</h3>
+                <input id="grant-search" type="text" class="input input-bordered w-full" placeholder="Search creations..." autocomplete="off">
+                <div id="grant-results" class="mt-2 space-x-2"></div>
+                <div id="grant-selected" class="mt-2 space-x-2"></div>
+                {{ form.grants }}
             </div>
             <div>
-                <label for="{{ form.prerequisite_total_level.id_for_label }}" class="block mb-1">Total Level</label>
-                {{ form.prerequisite_total_level }}
-            </div>
-            <div>
-                <label for="{{ form.prerequisite_species.id_for_label }}" class="block mb-1">Species</label>
-                {{ form.prerequisite_species }}
+                <h3 class="font-semibold mb-2">Modifiers</h3>
+                <div class="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
+                    <div>
+                        <label for="modifier-target" class="block mb-1">Target</label>
+                        <select id="modifier-target" class="select select-bordered w-full"></select>
+                    </div>
+                    <div>
+                        <label for="modifier-operation" class="block mb-1">Operation</label>
+                        <select id="modifier-operation" class="select select-bordered w-full">
+                            <option value="set">Set</option>
+                            <option value="add">Add</option>
+                            <option value="subtract">Subtract</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="modifier-value" class="block mb-1">Value</label>
+                        <input id="modifier-value-number" type="number" class="input input-bordered w-full" />
+                        <select id="modifier-value-bool" class="select select-bordered w-full hidden">
+                            <option value="true">True</option>
+                            <option value="false">False</option>
+                        </select>
+                        <input id="modifier-value-text" type="text" class="input input-bordered w-full hidden" />
+                    </div>
+                    <div>
+                        <button type="button" id="modifier-add" class="btn btn-outline">Add Modifier</button>
+                    </div>
+                </div>
+                <div id="modifier-list" class="mt-3 space-x-2"></div>
+                {{ form.modifiers }}
             </div>
         </div>
     </fieldset>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-            <label for="{{ form.charges.id_for_label }}" class="block mb-1">Charges</label>
-            {{ form.charges }}
-        </div>
-        <div>
-            <label for="{{ form.recharge_type.id_for_label }}" class="block mb-1">Recharge Type</label>
-            {{ form.recharge_type }}
-        </div>
-    </div>
-    <div>
-        <label class="block mb-1 font-semibold">Grants (optional)</label>
-        <input id="grant-search" type="text" class="input input-bordered w-full" placeholder="Search creations..." autocomplete="off">
-        <div id="grant-results" class="mt-2 space-x-2"></div>
-        <div id="grant-selected" class="mt-2 space-x-2"></div>
-        {{ form.grants }}
-    </div>
     <div>
         <button type="submit" class="btn btn-primary">Save Feature</button>
     </div>
@@ -110,5 +149,130 @@ searchInput.addEventListener('input', () => {
       });
     });
 });
+
+// ---- Modifiers UI ----
+const modifierTargets = [
+  { value: 'str_score', label: 'Strength Score', type: 'int' },
+  { value: 'dex_score', label: 'Dexterity Score', type: 'int' },
+  { value: 'con_score', label: 'Constitution Score', type: 'int' },
+  { value: 'int_score', label: 'Intelligence Score', type: 'int' },
+  { value: 'wis_score', label: 'Wisdom Score', type: 'int' },
+  { value: 'cha_score', label: 'Charisma Score', type: 'int' },
+  { value: 'xp', label: 'Experience Points', type: 'int' },
+  { value: 'hp_current', label: 'HP Current', type: 'int' },
+  { value: 'hp_temp', label: 'HP Temporary', type: 'int' },
+  { value: 'inspiration', label: 'Inspiration', type: 'bool' },
+  // Extend as needed
+];
+
+const modifierTargetSelect = document.getElementById('modifier-target');
+const modifierOpSelect = document.getElementById('modifier-operation');
+const modifierValueNumber = document.getElementById('modifier-value-number');
+const modifierValueBool = document.getElementById('modifier-value-bool');
+const modifierValueText = document.getElementById('modifier-value-text');
+const modifierAddBtn = document.getElementById('modifier-add');
+const modifierList = document.getElementById('modifier-list');
+const modifiersHidden = document.getElementById('id_modifiers');
+
+// Populate target dropdown
+modifierTargets.forEach(t => {
+  const opt = document.createElement('option');
+  opt.value = t.value;
+  opt.textContent = t.label;
+  modifierTargetSelect.appendChild(opt);
+});
+
+function currentTargetMeta() {
+  const val = modifierTargetSelect.value;
+  return modifierTargets.find(t => t.value === val) || modifierTargets[0];
+}
+
+function updateValueInputForTarget() {
+  const meta = currentTargetMeta();
+  // Show/hide value inputs based on type
+  if (meta.type === 'int') {
+    modifierValueNumber.classList.remove('hidden');
+    modifierValueBool.classList.add('hidden');
+    modifierValueText.classList.add('hidden');
+    // All operations valid
+    Array.from(modifierOpSelect.options).forEach(o => o.disabled = false);
+  } else if (meta.type === 'bool') {
+    modifierValueNumber.classList.add('hidden');
+    modifierValueBool.classList.remove('hidden');
+    modifierValueText.classList.add('hidden');
+    // Only 'set' is valid
+    modifierOpSelect.value = 'set';
+    Array.from(modifierOpSelect.options).forEach(o => {
+      o.disabled = (o.value !== 'set');
+    });
+  } else { // text
+    modifierValueNumber.classList.add('hidden');
+    modifierValueBool.classList.add('hidden');
+    modifierValueText.classList.remove('hidden');
+    // Only 'set' is valid for text
+    modifierOpSelect.value = 'set';
+    Array.from(modifierOpSelect.options).forEach(o => {
+      o.disabled = (o.value !== 'set');
+    });
+  }
+}
+
+modifierTargetSelect.addEventListener('change', updateValueInputForTarget);
+updateValueInputForTarget();
+
+function renderModifiersHidden() {
+  const list = Array.from(modifierList.children).map(el => {
+    const meta = modifierTargets.find(t => t.value === el.dataset.target);
+    let value;
+    if (el.dataset.type === 'int') {
+      value = parseInt(el.dataset.value);
+    } else if (el.dataset.type === 'bool') {
+      value = (el.dataset.value === 'true');
+    } else {
+      value = el.dataset.value;
+    }
+    return { target: el.dataset.target, operation: el.dataset.operation, value };
+  });
+  modifiersHidden.value = JSON.stringify(list);
+}
+
+function addModifier() {
+  const meta = currentTargetMeta();
+  const op = modifierOpSelect.value;
+  let valueRaw;
+  if (meta.type === 'int') {
+    const n = parseInt(modifierValueNumber.value);
+    if (isNaN(n)) { return; }
+    valueRaw = String(n);
+  } else if (meta.type === 'bool') {
+    valueRaw = modifierValueBool.value; // 'true' | 'false'
+  } else {
+    if (!modifierValueText.value.trim()) { return; }
+    valueRaw = modifierValueText.value.trim();
+  }
+
+  const badge = document.createElement('span');
+  badge.className = 'badge badge-outline mr-1 mb-1';
+  const label = `${meta.label}: ${op} ${meta.type === 'bool' ? (valueRaw === 'true' ? 'True' : 'False') : valueRaw}`;
+  badge.textContent = label;
+  badge.dataset.target = meta.value;
+  badge.dataset.operation = op;
+  badge.dataset.value = valueRaw;
+  badge.dataset.type = meta.type;
+
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'ml-1 text-xs';
+  btn.textContent = '\u2715';
+  btn.addEventListener('click', () => {
+    modifierList.removeChild(badge);
+    renderModifiersHidden();
+  });
+  badge.appendChild(btn);
+  modifierList.appendChild(badge);
+  renderModifiersHidden();
+}
+
+modifierAddBtn.addEventListener('click', addModifier);
 </script>
 {% endblock %}

--- a/core/templates/feat_form.html
+++ b/core/templates/feat_form.html
@@ -1,0 +1,114 @@
+{% extends "base.html" %}
+{% block title %}Create Feature{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Create Feature</h1>
+<form method="post" class="space-y-6">
+    {% csrf_token %}
+    <div>
+        <label for="{{ form.name.id_for_label }}" class="block mb-1 font-semibold">Name</label>
+        {{ form.name }}
+    </div>
+    <div>
+        <label for="{{ form.description.id_for_label }}" class="block mb-1 font-semibold">Description</label>
+        {{ form.description }}
+    </div>
+    <fieldset class="border p-4 rounded-lg">
+        <legend class="font-semibold">Prerequisites (optional)</legend>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label for="{{ form.prerequisite_class.id_for_label }}" class="block mb-1">Class</label>
+                {{ form.prerequisite_class }}
+            </div>
+            <div>
+                <label for="{{ form.prerequisite_class_level.id_for_label }}" class="block mb-1">Class Level</label>
+                {{ form.prerequisite_class_level }}
+            </div>
+            <div>
+                <label for="{{ form.prerequisite_feature.id_for_label }}" class="block mb-1">Feature</label>
+                {{ form.prerequisite_feature }}
+            </div>
+            <div>
+                <label for="{{ form.prerequisite_total_level.id_for_label }}" class="block mb-1">Total Level</label>
+                {{ form.prerequisite_total_level }}
+            </div>
+            <div>
+                <label for="{{ form.prerequisite_species.id_for_label }}" class="block mb-1">Species</label>
+                {{ form.prerequisite_species }}
+            </div>
+        </div>
+    </fieldset>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+            <label for="{{ form.charges.id_for_label }}" class="block mb-1">Charges</label>
+            {{ form.charges }}
+        </div>
+        <div>
+            <label for="{{ form.recharge_type.id_for_label }}" class="block mb-1">Recharge Type</label>
+            {{ form.recharge_type }}
+        </div>
+    </div>
+    <div>
+        <label class="block mb-1 font-semibold">Grants (optional)</label>
+        <input id="grant-search" type="text" class="input input-bordered w-full" placeholder="Search creations..." autocomplete="off">
+        <div id="grant-results" class="mt-2 space-x-2"></div>
+        <div id="grant-selected" class="mt-2 space-x-2"></div>
+        {{ form.grants }}
+    </div>
+    <div>
+        <button type="submit" class="btn btn-primary">Save Feature</button>
+    </div>
+</form>
+{% endblock %}
+{% block extra_scripts %}
+<script>
+const searchInput = document.getElementById('grant-search');
+const resultsDiv = document.getElementById('grant-results');
+const selectedDiv = document.getElementById('grant-selected');
+const hiddenInput = document.getElementById('id_grants');
+
+function updateHidden() {
+  const data = Array.from(selectedDiv.children).map(el => ({model: el.dataset.model, id: parseInt(el.dataset.id)}));
+  hiddenInput.value = JSON.stringify(data);
+}
+
+function addGrant(item) {
+  const badge = document.createElement('span');
+  badge.className = 'badge badge-outline mr-1 mb-1';
+  badge.textContent = item.model + ': ' + item.name;
+  badge.dataset.model = item.model;
+  badge.dataset.id = item.id;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'ml-1 text-xs';
+  btn.textContent = '\u2715';
+  btn.addEventListener('click', () => {
+    selectedDiv.removeChild(badge);
+    updateHidden();
+  });
+  badge.appendChild(btn);
+  selectedDiv.appendChild(badge);
+  updateHidden();
+}
+
+searchInput.addEventListener('input', () => {
+  const q = searchInput.value.trim();
+  if (!q) {
+    resultsDiv.innerHTML = '';
+    return;
+  }
+  fetch(`/api/search?q=${encodeURIComponent(q)}`)
+    .then(resp => resp.json())
+    .then(data => {
+      resultsDiv.innerHTML = '';
+      data.results.forEach(item => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'btn btn-xs btn-outline mr-1 mb-1';
+        btn.textContent = item.model + ': ' + item.name;
+        btn.addEventListener('click', () => addGrant(item));
+        resultsDiv.appendChild(btn);
+      });
+    });
+});
+</script>
+{% endblock %}

--- a/core/templates/home.html
+++ b/core/templates/home.html
@@ -60,7 +60,7 @@
         <h3 class="card-title">Homebrew</h3>
         <div class="mt-2 space-y-3">
           <a class="btn btn-outline btn-block" href="#">My Creations</a>
-          <a class="btn btn-outline btn-block" href="#">Create Feature</a>
+          <a class="btn btn-outline btn-block" href="{% url 'core:feat_create' %}">Create Feature</a>
           <a class="btn btn-outline btn-block" href="#">Create Class</a>
           <a class="btn btn-outline btn-block" href="#">Create Subclass</a>
           <a class="btn btn-outline btn-block" href="#">Create Item</a>

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,1 +1,52 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
 
+from .models import Feat, Class
+
+
+class FeatCreateTests(TestCase):
+    def setUp(self) -> None:
+        User = get_user_model()
+        self.user = User.objects.create_user(username="tester", password="pw")
+
+    def test_login_required(self) -> None:
+        response = self.client.get(reverse("core:feat_create"))
+        self.assertEqual(response.status_code, 302)
+
+    def test_create_feat_minimal(self) -> None:
+        self.client.login(username="tester", password="pw")
+        response = self.client.post(
+            reverse("core:feat_create"),
+            {"name": "Alert", "description": "Always on guard"},
+        )
+        self.assertEqual(response.status_code, 302)
+        feat = Feat.objects.get(name="Alert")
+        self.assertEqual(feat.description, "Always on guard")
+        self.assertEqual(feat.data, {})
+
+    def test_create_feat_with_options(self) -> None:
+        self.client.login(username="tester", password="pw")
+        prereq_class = Class.objects.create(name="Wizard")
+        existing = Feat.objects.create(name="Existing", description="desc")
+        payload = {
+            "name": "Magic Adept",
+            "description": "desc",
+            "prerequisite_class": prereq_class.id,
+            "prerequisite_class_level": 3,
+            "charges": 2,
+            "recharge_type": "long rest",
+            "grants": f"[{{\"model\": \"feat\", \"id\": {existing.id}}}]",
+        }
+        response = self.client.post(reverse("core:feat_create"), payload)
+        self.assertEqual(response.status_code, 302)
+        feat = Feat.objects.get(name="Magic Adept")
+        self.assertEqual(
+            feat.data.get("prerequisites", {}).get("class"), prereq_class.id
+        )
+        self.assertEqual(
+            feat.data.get("prerequisites", {}).get("class_level"), 3
+        )
+        self.assertEqual(feat.data.get("charges"), 2)
+        self.assertEqual(feat.data.get("recharge_type"), "long rest")
+        self.assertEqual(feat.data.get("grants"), [{"model": "feat", "id": existing.id}])

--- a/core/urls.py
+++ b/core/urls.py
@@ -5,7 +5,9 @@ app_name = "core"
 
 urlpatterns =[
     path("", views.home, name="home"),
+    path("features/create/", views.feat_create, name="feat_create"),
     path("dice-theme/<str:base_b64>/<path:res_path>", views.dice_theme_proxy, name="dice_theme_proxy"),
     path("api/dice-theme/test", views.dice_theme_test, name="dice_theme_test"),
     path("api/dice-theme/load", views.dice_theme_load, name="dice_theme_load"),
+    path("api/search", views.creation_search, name="creation_search"),
 ]


### PR DESCRIPTION
## Summary
- add feature creation form with optional prerequisites, charges, and grants stored in Feat.data
- link homepage button to new view and provide search API for grants
- document feature data usage in AGENTS guidelines

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c748ec72ec8323a194dbd1a1dca5b6